### PR TITLE
Simplify Android settings configuration

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,23 +1,2 @@
-pluginManagement {
-  repositories {
-    gradlePluginPortal()
-    google()
-    mavenCentral()
-  }
-}
-
-dependencyResolutionManagement {
-  repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
-  repositories {
-    google()
-    mavenCentral()
-  }
-}
-
 rootProject.name = "RMZWallet"
-
-// Solo tu app RN; sin módulos de Capacitor
 include(":app")
-
-// Usa el plugin de RN desde node_modules (no necesita versión ni token)
-includeBuild("../node_modules/react-native-gradle-plugin")


### PR DESCRIPTION
## Summary
- simplify `android/settings.gradle` to only include the standard project configuration for the app module.

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f20f89b0833280b753cf42114a33