### PR TITLE
Disable Hermes in favor of JavaScriptCore

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -36,4 +36,5 @@ newArchEnabled=false
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
-hermesEnabled=true
+# Usar JavaScriptCore en lugar de Hermes
+hermesEnabled=false


### PR DESCRIPTION
## Summary
- disable Hermes in the Android Gradle configuration so the app uses JavaScriptCore instead
- add a comment noting the JavaScriptCore preference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f3c319d483329c8a7d9c37a4ab09