### PR TITLE
Update Gradle wrapper for AGP 8.1.1

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,4 @@
+# Gradle 8.1.1 is required for Android Gradle Plugin 8.1.1 compatibility
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip


### PR DESCRIPTION
## Summary
- add a comment documenting the Gradle 8.1.1 requirement for Android Gradle Plugin 8.1.1 in the wrapper configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f42992b0833293ceb0b43c05057d