### PR TITLE
chore: update wasm polyfill deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "react-native-qrcode-svg": "^6.3.15",
         "react-native-quick-crypto": "^0.7.17",
         "react-native-svg": "^15.13.0",
-        "react-native-url-polyfill": "^2.0.0",
+        "react-native-url-polyfill": "^3.0.0",
         "text-encoding": "^0.7.0",
         "text-encoding-polyfill": "^0.6.7"
       },
@@ -11135,9 +11135,9 @@
       }
     },
     "node_modules/react-native-url-polyfill": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
-      "integrity": "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-3.0.0.tgz",
+      "integrity": "sha512-aA5CiuUCUb/lbrliVCJ6lZ17/RpNJzvTO/C7gC/YmDQhTUoRD5q5HlJfwLWcxz4VgAhHwXKzhxH+wUN24tAdqg==",
       "license": "MIT",
       "dependencies": {
         "whatwg-url-without-unicode": "8.0.0-3"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-native-qrcode-svg": "^6.3.15",
     "react-native-quick-crypto": "^0.7.17",
     "react-native-svg": "^15.13.0",
-    "react-native-url-polyfill": "^2.0.0",
+    "react-native-url-polyfill": "^3.0.0",
     "text-encoding": "^0.7.0",
     "text-encoding-polyfill": "^0.6.7"
   },


### PR DESCRIPTION
## Summary
- update react-native-url-polyfill to the latest major release to ensure up-to-date WebAssembly polyfills
- refresh the lockfile to capture the new dependency version

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68d7f5383b948332856cc283eefbc372