### PR TITLE
Update Android settings.gradle configuration

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,19 @@
+pluginManagement {
+  includeBuild("../node_modules/@react-native/gradle-plugin")
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+    google()
+  }
+}
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+  repositories {
+    mavenCentral()
+    google()
+  }
+}
+
 rootProject.name = "RMZWallet"
 include(":app")


### PR DESCRIPTION
## Summary
- configure plugin management to include the React Native Gradle plugin build
- set dependency resolution management repositories to prefer project settings
- retain project name and app module inclusion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fab4a3688332b9ddd9340d464ad0