### PR TITLE
Ensure Gradle wrapper uses full 8.1.1 distribution

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,5 @@
 # Gradle 8.1.1 is required for Android Gradle Plugin 8.1.1 compatibility
+# Ensure wrapper uses the matching full distribution
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip


### PR DESCRIPTION
## Summary
- add a note to the Gradle wrapper properties to ensure the project uses the Gradle 8.1.1 all distribution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fdb531d88332add58954f941163b