### PR TITLE
Add polyfill bootstrap for crypto and text APIs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,4 @@
-// Polyfills necesarios para React Native (ejecución en móvil)
-import { encode, decode } from 'base-64';
-if (!global.btoa) global.btoa = encode;
-if (!global.atob) global.atob = decode;
-
-import 'react-native-url-polyfill/auto';
-import 'text-encoding-polyfill';
-import 'react-native-get-random-values';
-
-import { install as installQuickCrypto } from 'react-native-quick-crypto';
-installQuickCrypto();
-
-import { Buffer } from 'buffer';
-if (!global.Buffer) global.Buffer = Buffer;
+import './src/polyfills';
 
 import { AppRegistry } from 'react-native';
 import App from './src/App';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,33 @@
+import { encode, decode } from 'base-64';
+
+if (!global.btoa) {
+  global.btoa = encode;
+}
+
+if (!global.atob) {
+  global.atob = decode;
+}
+
+import 'react-native-url-polyfill/auto';
+import 'text-encoding-polyfill';
+import 'react-native-get-random-values';
+
+import { install as installQuickCrypto } from 'react-native-quick-crypto';
+
+installQuickCrypto();
+
+import { Buffer } from 'buffer';
+
+if (!global.Buffer) {
+  global.Buffer = Buffer;
+}
+
+if (typeof global.TextEncoder === 'undefined' &&
+    typeof globalThis.TextEncoder !== 'undefined') {
+  global.TextEncoder = globalThis.TextEncoder;
+}
+
+if (typeof global.TextDecoder === 'undefined' &&
+    typeof globalThis.TextDecoder !== 'undefined') {
+  global.TextDecoder = globalThis.TextDecoder;
+}


### PR DESCRIPTION
## Summary
- move the React Native runtime polyfill setup into a dedicated bootstrap module
- ensure required crypto, buffer, base64, URL, and text encoders are initialised globally for ecash-lib

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ff9cb65083328dc9b73bc6c5e90e