### PR TITLE
Implement Chronik-backed sendRawTx helper

### DIFF
--- a/src/core/enviar.js
+++ b/src/core/enviar.js
@@ -1,7 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { mnemonicToSeed } from 'bip39';
+import * as bip39 from 'bip39';
 import { ChronikClient } from 'chronik-client';
 import {
+  Address,
   HdNode,
   Script,
   TxBuilder,
@@ -13,13 +14,11 @@ import {
 const STORAGE_KEY = 'rmz_wallet';
 const DERIVATION_PATH = "m/44'/899'/0'/0/0";
 const CHRONIK_URL = 'https://chronik.e.cash';
-const FEE_PER_KB = 1000n; // 1 sat/byte
+const FIXED_FEE_SATS = 1000n;
 const DUST_SATS = 546n;
 
 const toBigInt = (value) => {
-  if (typeof value === 'bigint') {
-    return value;
-  }
+  if (typeof value === 'bigint') return value;
   if (typeof value === 'number') {
     if (!Number.isFinite(value)) {
       throw new Error('Valor numérico inválido');
@@ -41,163 +40,138 @@ const xecToSats = (amount) => {
   if (!/^\d+$/.test(ints)) {
     throw new Error('Monto inválido');
   }
-  if (decimals.length > 2) {
+  if (!/^\d*$/.test(decimals) || decimals.length > 2) {
     throw new Error('El monto XEC admite máximo 2 decimales');
   }
   const dec = (decimals + '00').slice(0, 2);
   return BigInt(ints) * 100n + BigInt(dec || '0');
 };
 
-const loadStoredWallet = async () => {
-  const raw = await AsyncStorage.getItem(STORAGE_KEY);
-  if (!raw) {
-    throw new Error('No hay cartera almacenada');
+const loadWallet = async () => {
+  const stored = await AsyncStorage.getItem(STORAGE_KEY);
+  if (!stored) {
+    throw new Error('No hay cartera guardada');
   }
+  let parsed;
   try {
-    const wallet = JSON.parse(raw);
-    if (!wallet?.mnemonic || !wallet?.address) {
-      throw new Error('Cartera incompleta');
-    }
-    return wallet;
-  } catch (err) {
+    parsed = JSON.parse(stored);
+  } catch (error) {
     throw new Error('Cartera almacenada inválida');
   }
+  if (!parsed?.mnemonic || !parsed?.address) {
+    throw new Error('Cartera incompleta');
+  }
+  return parsed;
 };
 
-const buildSignedTx = ({
-  utxos,
-  amountSats,
-  destScript,
-  changeScript,
-  signatory,
-  spendScript,
-}) => {
-  const inputs = utxos.map((coin) => ({
+const buildInputs = (utxos, signatory, spendScript) =>
+  utxos.map((utxo) => ({
     input: {
       prevOut: {
-        txid: coin.outpoint.txid,
-        outIdx: coin.outpoint.outIdx,
+        txid: utxo.outpoint.txid,
+        outIdx: utxo.outpoint.outIdx,
       },
       signData: {
-        sats: toBigInt(coin.sats),
-        outputScript: spendScript,
+        sats: toBigInt(utxo.sats),
+        outputScript: spendScript.copy(),
       },
     },
     signatory,
   }));
 
-  const builder = new TxBuilder({
-    inputs,
-    outputs: [
-      { sats: amountSats, script: destScript.copy() },
-      changeScript.copy(),
-    ],
-  });
+export async function sendRawTx(destino, amountXec) {
+  try {
+    if (!destino) {
+      throw new Error('Dirección destino requerida');
+    }
 
-  return builder.sign({ feePerKb: FEE_PER_KB, dustSats: DUST_SATS });
-};
+    const { mnemonic } = await loadWallet();
+    const satsOut = xecToSats(amountXec);
+    if (satsOut <= 0n) {
+      throw new Error('El monto debe ser mayor que 0');
+    }
 
-export async function sendRawTx(destino, montoXec) {
-  if (!destino) {
-    throw new Error('Dirección destino requerida');
-  }
+    const seed = await bip39.mnemonicToSeed(mnemonic);
+    const master = HdNode.fromSeed(new Uint8Array(seed));
+    const accountNode = master.derivePath(DERIVATION_PATH);
 
-  const { mnemonic, address } = await loadStoredWallet();
-  const amountSats = xecToSats(montoXec);
-  if (amountSats <= 0n) {
-    throw new Error('El monto debe ser mayor que 0');
-  }
+    const privKey = accountNode.seckey();
+    if (!privKey) {
+      throw new Error('No se pudo derivar la clave privada');
+    }
+    const pubKey = accountNode.pubkey();
+    const pubKeyHash = accountNode.pkh();
 
-  const seed = await mnemonicToSeed(mnemonic);
-  const master = HdNode.fromSeed(new Uint8Array(seed));
-  const node = master.derivePath(DERIVATION_PATH);
-  const seckey = node.seckey();
-  const pubkey = node.pubkey();
+    const fromAddress = Address.p2pkh(pubKeyHash).address;
+    const spendScript = Script.p2pkh(pubKeyHash);
+    const destScript = Script.fromAddress(destino);
+    const changeScript = Script.fromAddress(fromAddress);
+    const signatory = P2PKHSignatory(privKey, pubKey, ALL_BIP143);
 
-  if (!seckey) {
-    throw new Error('No se pudo derivar la clave privada');
-  }
+    const chronik = new ChronikClient(CHRONIK_URL);
+    const utxoResponse = await chronik.address(fromAddress).utxos();
+    const utxos = Array.isArray(utxoResponse?.utxos) ? utxoResponse.utxos : [];
+    const spendable = utxos.filter((utxo) => !utxo.token);
 
-  const spendScript = Script.p2pkh(node.pkh());
-  const destScript = Script.fromAddress(destino);
-  const changeScript = Script.fromAddress(address);
-  const signatory = P2PKHSignatory(seckey, pubkey, ALL_BIP143);
+    if (!spendable.length) {
+      throw new Error('No hay UTXOs disponibles');
+    }
 
-  const chronik = new ChronikClient(CHRONIK_URL);
-  const utxoResponse = await chronik.address(address).utxos();
-  const allUtxos = Array.isArray(utxoResponse?.utxos) ? utxoResponse.utxos : [];
-
-  if (!allUtxos.length) {
-    throw new Error('No hay fondos disponibles');
-  }
-
-  let chainInfo;
-  const spendable = [];
-  for (const coin of allUtxos) {
-    if (coin.token) continue;
-    if (coin.isCoinbase) {
-      if (coin.blockHeight < 0) continue;
-      if (!chainInfo) {
-        chainInfo = await chronik.blockchainInfo();
+    let chainInfo;
+    const mature = [];
+    for (const utxo of spendable) {
+      if (utxo.isCoinbase) {
+        if (utxo.blockHeight < 0) {
+          continue;
+        }
+        if (!chainInfo) {
+          chainInfo = await chronik.blockchainInfo();
+        }
+        if (!chainInfo || chainInfo.tipHeight - utxo.blockHeight < 100) {
+          continue;
+        }
       }
-      if (!chainInfo || chainInfo.tipHeight - coin.blockHeight < 100) {
-        continue;
+      mature.push(utxo);
+    }
+
+    if (!mature.length) {
+      throw new Error('No hay UTXOs disponibles para gastar');
+    }
+
+    const requiredTotal = satsOut + FIXED_FEE_SATS;
+    const selected = [];
+    let total = 0n;
+    for (const utxo of mature) {
+      selected.push(utxo);
+      total += toBigInt(utxo.sats);
+      if (total >= requiredTotal) {
+        break;
       }
     }
-    spendable.push(coin);
-  }
 
-  if (!spendable.length) {
-    throw new Error('No hay UTXOs disponibles para gastar');
-  }
-
-  spendable.sort((a, b) => {
-    const aSats = toBigInt(a.sats);
-    const bSats = toBigInt(b.sats);
-    if (aSats === bSats) {
-      return (a.blockHeight ?? 0) - (b.blockHeight ?? 0);
-    }
-    return aSats < bSats ? -1 : 1;
-  });
-
-  const selected = [];
-  let total = 0n;
-  let tx = null;
-  let lastError;
-
-  for (const coin of spendable) {
-    selected.push(coin);
-    total += toBigInt(coin.sats);
-    if (total < amountSats) {
-      continue;
+    if (total < requiredTotal) {
+      throw new Error('Fondos insuficientes');
     }
 
-    try {
-      tx = buildSignedTx({
-        utxos: selected,
-        amountSats,
-        destScript,
-        changeScript,
-        signatory,
-        spendScript,
-      });
-      break;
-    } catch (err) {
-      lastError = err;
+    const change = total - requiredTotal;
+    const outputs = [{ sats: satsOut, script: destScript.copy() }];
+    if (change >= DUST_SATS) {
+      outputs.push({ sats: change, script: changeScript.copy() });
     }
+
+    const builder = new TxBuilder({
+      inputs: buildInputs(selected, signatory, spendScript),
+      outputs,
+    });
+
+    const tx = builder.sign();
+    const rawHex = toHex(tx.ser());
+    const { txid } = await chronik.broadcastTx(rawHex);
+
+    return { success: true, txid };
+  } catch (error) {
+    return { success: false, error: error?.message || String(error) };
   }
-
-  if (!tx) {
-    if (lastError) {
-      throw lastError;
-    }
-    throw new Error('Fondos insuficientes para cubrir monto y comisión');
-  }
-
-  const rawTxHex = toHex(tx.ser());
-  const { txid } = await chronik.broadcastTx(rawTxHex);
-
-  return { txid, hex: rawTxHex };
 }
 
 export default sendRawTx;


### PR DESCRIPTION
## Summary
- derive the wallet key via ecash-lib using the eCash derivation path
- fetch Chronik UTXOs, assemble/sigh, and broadcast P2PKH transactions with change handling
- return structured success/error results from broadcasting the raw transaction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d80159c8948332bd470f03db33bc15