### PR TITLE
Fix Android build configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,19 +4,19 @@ plugins {
   id("com.facebook.react")
 }
 
-// Deja que el plugin de RN haga el autolink correctamente
 react {
   autolinkLibrariesWithApp()
 }
 
 android {
   namespace "com.rmzwallet"
-  compileSdkVersion 34
+  compileSdkVersion rootProject.ext.compileSdkVersion
+  buildToolsVersion rootProject.ext.buildToolsVersion
 
   defaultConfig {
     applicationId "com.rmzwallet"
-    minSdkVersion 21
-    targetSdkVersion 34
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
     versionCode 1
     versionName "1.0"
   }
@@ -30,8 +30,6 @@ android {
 }
 
 dependencies {
-  // El plugin de Kotlin ya añade stdlib, pero si quieres dejarlo explícito:
   implementation("org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}")
   implementation("androidx.core:core-ktx:1.9.0")
-  // IMPORTANTE: NADA de 'implementation project(":capacitor-android")' ni similares
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
   ext {
-    // Versiones usadas por los módulos
+    buildToolsVersion = "34.0.0"
     compileSdkVersion = 34
-    targetSdkVersion  = 34
-    minSdkVersion     = 23
-    kotlinVersion     = '1.9.0'
+    targetSdkVersion = 34
+    minSdkVersion = 23
+    kotlinVersion = "1.9.0"
   }
 
   repositories {
@@ -13,10 +13,8 @@ buildscript {
   }
 
   dependencies {
-    // AGP compatible con Gradle 8.1.1
     classpath("com.android.tools.build:gradle:8.1.1")
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
-    // NO agregar el plugin de RN aquí cuando usamos includeBuild() en settings.gradle
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
   }
 }
 
@@ -26,5 +24,3 @@ allprojects {
     mavenCentral()
   }
 }
-apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -12,6 +12,8 @@ dependencyResolutionManagement {
   repositories {
     mavenCentral()
     google()
+    maven { url("$rootDir/../node_modules/react-native/android") }
+    maven { url("$rootDir/../node_modules/jsc-android/dist") }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@babel/runtime": "^7.20.0",
         "@react-native/babel-preset": "0.75.5",
         "@react-native/eslint-config": "0.75.5",
+        "@react-native/gradle-plugin": "0.75.5",
         "@react-native/metro-config": "0.75.5",
         "@react-native/typescript-config": "0.75.5",
         "@types/react": "^18.2.6",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/runtime": "^7.20.0",
     "@react-native/babel-preset": "0.75.5",
     "@react-native/eslint-config": "0.75.5",
+    "@react-native/gradle-plugin": "0.75.5",
     "@react-native/metro-config": "0.75.5",
     "@react-native/typescript-config": "0.75.5",
     "@types/react": "^18.2.6",


### PR DESCRIPTION
## Summary
- configure Android Gradle scripts to source SDK versions from shared ext values and add build tools version
- ensure the React Native Gradle plugin can be resolved by updating settings repositories and adding it as a dev dependency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d80587384083329f073b50a1c71be6