### PR TITLE
Make RN Gradle plugin path robust

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,16 @@
 pluginManagement {
-  includeBuild("../node_modules/@react-native/gradle-plugin")
+  // Detect plugin location dynamically (classic vs scoped)
+  def rnPluginDir = file("../node_modules/react-native-gradle-plugin")
+  def rnPluginScopedDir = file("../node_modules/@react-native/gradle-plugin")
+
+  if (rnPluginDir.exists()) {
+    includeBuild("../node_modules/react-native-gradle-plugin")
+  } else if (rnPluginScopedDir.exists()) {
+    includeBuild("../node_modules/@react-native/gradle-plugin")
+  } else {
+    throw new GradleException("❌ React Native gradle plugin not found in node_modules.")
+  }
+
   repositories {
     gradlePluginPortal()
     mavenCentral()
@@ -8,12 +19,11 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
+  // Avoid conflict: prefer settings repositories
   repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
   repositories {
     mavenCentral()
     google()
-    maven { url("$rootDir/../node_modules/react-native/android") }
-    maven { url("$rootDir/../node_modules/jsc-android/dist") }
   }
 }
 


### PR DESCRIPTION
## Summary
- update android/settings.gradle to dynamically include the React Native Gradle plugin from classic or scoped package directories
- streamline dependency resolution repositories to avoid conflicts and align with settings-level configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80765b8c48332b5d709e5dbf3bf7b