### PR TITLE
feat: add ionic tabs navigation structure

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: 'tabs',
+    loadChildren: () =>
+      import('./pages/tabs/tabs.module').then((m) => m.TabsPageModule),
+  },
+  {
+    path: '',
+    redirectTo: 'tabs',
+    pathMatch: 'full',
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules })],
+  exports: [RouterModule],
+})
+export class AppRoutingModule {}

--- a/src/app/pages/settings/settings.module.ts
+++ b/src/app/pages/settings/settings.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { RouterModule, Routes } from '@angular/router';
+
+import { SettingsPage } from './settings.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SettingsPage,
+  },
+];
+
+@NgModule({
+  imports: [CommonModule, IonicModule, RouterModule.forChild(routes)],
+  declarations: [SettingsPage],
+})
+export class SettingsPageModule {}

--- a/src/app/pages/settings/settings.page.ts
+++ b/src/app/pages/settings/settings.page.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-settings',
+  template: `
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Configuración</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="ion-padding">
+      <p>
+        Aquí podrás personalizar la aplicación. Por ahora este es un texto placeholder
+        mientras definimos las opciones de configuración.
+      </p>
+    </ion-content>
+  `,
+})
+export class SettingsPage {}

--- a/src/app/pages/tabs/tabs-routing.module.ts
+++ b/src/app/pages/tabs/tabs-routing.module.ts
@@ -1,0 +1,41 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { TabsPage } from './tabs.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: TabsPage,
+    children: [
+      {
+        path: 'wallet',
+        loadChildren: () =>
+          import('../wallet/wallet.module').then((m) => m.WalletPageModule),
+      },
+      {
+        path: 'transactions',
+        loadChildren: () =>
+          import('../transactions/transactions.module').then(
+            (m) => m.TransactionsPageModule,
+          ),
+      },
+      {
+        path: 'settings',
+        loadChildren: () =>
+          import('../settings/settings.module').then((m) => m.SettingsPageModule),
+      },
+      {
+        path: '',
+        redirectTo: 'wallet',
+        pathMatch: 'full',
+      },
+    ],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class TabsPageRoutingModule {}

--- a/src/app/pages/tabs/tabs.module.ts
+++ b/src/app/pages/tabs/tabs.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+
+import { TabsPage } from './tabs.page';
+import { TabsPageRoutingModule } from './tabs-routing.module';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, TabsPageRoutingModule],
+  declarations: [TabsPage],
+})
+export class TabsPageModule {}

--- a/src/app/pages/tabs/tabs.page.ts
+++ b/src/app/pages/tabs/tabs.page.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-tabs',
+  template: `
+    <ion-tabs>
+      <ion-router-outlet></ion-router-outlet>
+
+      <ion-tab-bar slot="bottom">
+        <ion-tab-button tab="wallet" [routerLink]="['/tabs/wallet']">
+          <ion-label>Wallet</ion-label>
+        </ion-tab-button>
+
+        <ion-tab-button tab="transactions" [routerLink]="['/tabs/transactions']">
+          <ion-label>Transacciones</ion-label>
+        </ion-tab-button>
+
+        <ion-tab-button tab="settings" [routerLink]="['/tabs/settings']">
+          <ion-label>Configuración</ion-label>
+        </ion-tab-button>
+      </ion-tab-bar>
+    </ion-tabs>
+  `,
+})
+export class TabsPage {}

--- a/src/app/pages/transactions/transactions.module.ts
+++ b/src/app/pages/transactions/transactions.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { RouterModule, Routes } from '@angular/router';
+
+import { TransactionsPage } from './transactions.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: TransactionsPage,
+  },
+];
+
+@NgModule({
+  imports: [CommonModule, IonicModule, RouterModule.forChild(routes)],
+  declarations: [TransactionsPage],
+})
+export class TransactionsPageModule {}

--- a/src/app/pages/transactions/transactions.page.ts
+++ b/src/app/pages/transactions/transactions.page.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+
+interface TransactionItem {
+  id: number;
+  description: string;
+  amount: number;
+  date: string;
+}
+
+@Component({
+  selector: 'app-transactions',
+  template: `
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Transacciones</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="ion-padding">
+      <ion-list>
+        <ion-item *ngFor="let item of transactions">
+          <ion-label>
+            <h2>{{ item.description }}</h2>
+            <p>{{ item.date }}</p>
+          </ion-label>
+          <ion-note slot="end" color="primary">{{ item.amount | number: '1.2-2' }} XEC</ion-note>
+        </ion-item>
+      </ion-list>
+
+      <ion-item *ngIf="transactions.length === 0" lines="none">
+        <ion-label>No hay transacciones todavía.</ion-label>
+      </ion-item>
+    </ion-content>
+  `,
+})
+export class TransactionsPage {
+  readonly transactions: TransactionItem[] = [
+    { id: 1, description: 'Pago recibido', amount: 1250.5, date: '2024-10-01' },
+    { id: 2, description: 'Compra en tienda', amount: -230.75, date: '2024-09-26' },
+    { id: 3, description: 'Retiro en cajero', amount: -500.0, date: '2024-09-20' },
+  ];
+}

--- a/src/app/pages/wallet/wallet.module.ts
+++ b/src/app/pages/wallet/wallet.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+
+import { WalletPage } from './wallet.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: WalletPage,
+  },
+];
+
+@NgModule({
+  imports: [CommonModule, IonicModule, ReactiveFormsModule, RouterModule.forChild(routes)],
+  declarations: [WalletPage],
+})
+export class WalletPageModule {}


### PR DESCRIPTION
## Summary
- add an Ionic tabs container that routes to wallet, transactions, and settings sections
- scaffold dummy transactions list and placeholder settings page components
- provide routing modules for tabs and wallet to integrate with the Ionic router

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9565143d483329f2de8cb01178544