### PR TITLE
Implement wallet actions UI on home page

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,0 +1,93 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Inicio</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-button
+    expand="block"
+    color="primary"
+    (click)="onCreateWallet()"
+    [disabled]="isCreatingWallet || isLoadingWallet"
+  >
+    {{ isCreatingWallet ? 'Creando cartera…' : 'Crear Cartera' }}
+  </ion-button>
+
+  <ion-card *ngIf="hasWallet" class="wallet-card">
+    <ion-card-header>
+      <ion-card-title>Mi Cartera</ion-card-title>
+    </ion-card-header>
+
+    <ion-card-content>
+      <div class="wallet-row">
+        <p class="wallet-label">Dirección</p>
+        <p class="wallet-value">{{ wallet?.address }}</p>
+      </div>
+
+      <div class="wallet-row">
+        <p class="wallet-label">Saldo</p>
+        <p class="wallet-value">{{ formattedBalance }}</p>
+      </div>
+
+      <ion-button
+        expand="block"
+        fill="outline"
+        color="medium"
+        (click)="refreshBalance()"
+        [disabled]="isRefreshingBalance"
+      >
+        {{ isRefreshingBalance ? 'Actualizando…' : 'Actualizar saldo' }}
+      </ion-button>
+
+      <ion-button expand="block" color="secondary" (click)="openSendModal()">
+        Enviar
+      </ion-button>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-item *ngIf="errorMessage" lines="none" class="error-item">
+    <ion-text color="danger">{{ errorMessage }}</ion-text>
+  </ion-item>
+
+  <ion-modal [isOpen]="isSendModalOpen" (didDismiss)="closeSendModal()">
+    <ng-template>
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Enviar XEC</ion-title>
+          <ion-buttons slot="end">
+            <ion-button (click)="closeSendModal()">Cerrar</ion-button>
+          </ion-buttons>
+        </ion-toolbar>
+      </ion-header>
+
+      <ion-content class="ion-padding">
+        <form [formGroup]="sendForm" (ngSubmit)="onSubmitSend()">
+          <ion-item>
+            <ion-label position="stacked">Dirección destino</ion-label>
+            <ion-input
+              formControlName="destination"
+              autocomplete="off"
+              autocorrect="off"
+              autocapitalize="off"
+            ></ion-input>
+          </ion-item>
+
+          <ion-item>
+            <ion-label position="stacked">Monto (XEC)</ion-label>
+            <ion-input type="number" formControlName="amount" min="0" step="0.000001"></ion-input>
+          </ion-item>
+
+          <ion-button
+            expand="block"
+            type="submit"
+            color="primary"
+            [disabled]="sendForm.invalid || isSending"
+          >
+            {{ isSending ? 'Enviando…' : 'Enviar' }}
+          </ion-button>
+        </form>
+      </ion-content>
+    </ng-template>
+  </ion-modal>
+</ion-content>

--- a/src/app/home/home.page.scss
+++ b/src/app/home/home.page.scss
@@ -1,0 +1,21 @@
+.wallet-card {
+  margin-top: 1.5rem;
+}
+
+.wallet-row {
+  margin-bottom: 1rem;
+}
+
+.wallet-label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.wallet-value {
+  word-break: break-word;
+  margin: 0;
+}
+
+.error-item {
+  margin-top: 1rem;
+}

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,0 +1,170 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Toast } from '@capacitor/toast';
+
+import { WalletService, WalletSnapshot } from '../services/wallet.service';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.page.html',
+  styleUrls: ['./home.page.scss'],
+})
+export class HomePage implements OnInit {
+  wallet: WalletSnapshot | null = null;
+  balance: number | null = null;
+  isLoadingWallet = false;
+  isCreatingWallet = false;
+  isRefreshingBalance = false;
+  isSendModalOpen = false;
+  isSending = false;
+  errorMessage = '';
+
+  readonly sendForm: FormGroup;
+
+  constructor(
+    private readonly walletService: WalletService,
+    formBuilder: FormBuilder,
+  ) {
+    this.sendForm = formBuilder.group({
+      destination: ['', Validators.required],
+      amount: [null, [Validators.required, Validators.min(0.000001)]],
+    });
+
+    const service = this.walletService as WalletService & {
+      sendTx?: (destination: string, amount: number) => Promise<string>;
+      send?: (destination: string, amount: number) => Promise<string>;
+    };
+
+    if (typeof service.sendTx !== 'function' && typeof service.send === 'function') {
+      service.sendTx = service.send.bind(this.walletService);
+    }
+  }
+
+  async ngOnInit(): Promise<void> {
+    await this.loadWallet();
+  }
+
+  get hasWallet(): boolean {
+    return !!this.wallet?.address;
+  }
+
+  get formattedBalance(): string {
+    if (this.balance === null || Number.isNaN(this.balance)) {
+      return '--';
+    }
+
+    return `${this.balance.toLocaleString('es-ES', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 8,
+    })} XEC`;
+  }
+
+  async loadWallet(): Promise<void> {
+    this.isLoadingWallet = true;
+    this.errorMessage = '';
+
+    try {
+      this.wallet = await this.walletService.loadWallet();
+      if (this.wallet) {
+        await this.refreshBalance();
+      } else {
+        this.balance = null;
+      }
+    } catch (error) {
+      this.errorMessage = this.resolveErrorMessage(error);
+    } finally {
+      this.isLoadingWallet = false;
+    }
+  }
+
+  async onCreateWallet(): Promise<void> {
+    this.isCreatingWallet = true;
+    this.errorMessage = '';
+
+    try {
+      this.wallet = await this.walletService.createWallet();
+      await this.refreshBalance();
+      await Toast.show({ text: 'Cartera creada correctamente.' });
+    } catch (error) {
+      this.errorMessage = this.resolveErrorMessage(error);
+    } finally {
+      this.isCreatingWallet = false;
+    }
+  }
+
+  async refreshBalance(): Promise<void> {
+    if (!this.wallet?.address) {
+      return;
+    }
+
+    this.isRefreshingBalance = true;
+    this.errorMessage = '';
+
+    try {
+      this.balance = await this.walletService.getBalance();
+    } catch (error) {
+      this.errorMessage = this.resolveErrorMessage(error);
+    } finally {
+      this.isRefreshingBalance = false;
+    }
+  }
+
+  openSendModal(): void {
+    this.sendForm.reset({ destination: '', amount: null });
+    this.isSendModalOpen = true;
+  }
+
+  closeSendModal(): void {
+    this.isSendModalOpen = false;
+  }
+
+  async onSubmitSend(): Promise<void> {
+    if (!this.wallet?.address) {
+      this.errorMessage = 'Debes crear una cartera antes de enviar fondos.';
+      return;
+    }
+
+    if (this.sendForm.invalid) {
+      this.sendForm.markAllAsTouched();
+      return;
+    }
+
+    const destination = String(this.sendForm.value.destination ?? '').trim();
+    const amount = Number(this.sendForm.value.amount);
+
+    if (!destination) {
+      this.errorMessage = 'La dirección de destino es obligatoria.';
+      return;
+    }
+
+    if (!Number.isFinite(amount) || amount <= 0) {
+      this.errorMessage = 'El monto debe ser mayor que cero.';
+      return;
+    }
+
+    this.isSending = true;
+    this.errorMessage = '';
+
+    try {
+      const service = this.walletService as WalletService & {
+        sendTx: (destination: string, amount: number) => Promise<string>;
+      };
+      const txid = await service.sendTx(destination, amount);
+      await Toast.show({ text: `Transacción enviada: ${txid}` });
+      this.closeSendModal();
+      await this.refreshBalance();
+    } catch (error) {
+      this.errorMessage = this.resolveErrorMessage(error);
+    } finally {
+      this.isSending = false;
+    }
+  }
+
+  private resolveErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return String(error ?? 'Ocurrió un error desconocido.');
+  }
+}


### PR DESCRIPTION
## Summary
- add a home page component that can create the wallet, refresh balance, and trigger the send modal
- wire the send form to call `walletService.sendTx` and show the transaction id with a Capacitor toast
- style the wallet card and error message layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d95c400e188332b06e4dbdd60b01ae