### PR TITLE
Configure Angular production settings and Ionic build scripts

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "defaultProject": "rmzwallet",
+  "projects": {
+    "rmzwallet": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "www",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": ["src/polyfills.ts"],
+            "tsConfig": "tsconfig.json",
+            "assets": [],
+            "styles": [],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "optimization": {
+                "scripts": true,
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": true
+                }
+              },
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb",
+                  "maximumError": "10kb"
+                }
+              ]
+            },
+            "development": {
+              "optimization": false,
+              "sourceMap": true,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "buildOptimizer": false
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "rmzwallet:build:development"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "rmzwallet:build:production"
+            },
+            "development": {
+              "browserTarget": "rmzwallet:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "android": "react-native run-android",
+    "build": "ionic build",
+    "android": "ionic capacitor run android",
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>RMZ Wallet</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <app-root>RMZ Wallet build placeholder</app-root>
+  </body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,7 @@
+/**
+ * Placeholder entry point for Angular-style builds.
+ * Replace with a proper bootstrap once the web UI is migrated to Angular.
+ */
+if (typeof window !== 'undefined') {
+  console.log('RMZ Wallet production build placeholder loaded.');
+}


### PR DESCRIPTION
## Summary
- add an `angular.json` configuration that targets production builds and serves as the default for the project
- add placeholder `src/index.html` and `src/main.ts` files expected by the Angular tooling used during Ionic builds
- update the npm scripts to run `ionic build` and `ionic capacitor run android`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95eb706ac8332b72ca03a79f58d75