### PR TITLE
Ensure MainActivity extends BridgeActivity

### DIFF
--- a/android/app/src/main/java/com/rmz/wallet/MainActivity.java
+++ b/android/app/src/main/java/com/rmz/wallet/MainActivity.java
@@ -1,0 +1,5 @@
+package com.rmz.wallet;
+
+import com.getcapacitor.BridgeActivity;
+
+public class MainActivity extends BridgeActivity {}


### PR DESCRIPTION
## Summary
- ensure the Android MainActivity is defined to extend Capacitor's BridgeActivity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d975ce9454833290066d13ca77a2d1