### PR TITLE
Configure Android SDK versions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'com.android.application'
+
+android {
+    namespace "com.rmz.wallet"
+    compileSdkVersion 34
+
+    defaultConfig {
+        applicationId "com.rmz.wallet"
+        minSdkVersion 21
+        targetSdkVersion 34
+        versionCode 1
+        versionName "1.0"
+    }
+}


### PR DESCRIPTION
## Summary
- add an Android module build.gradle file for the Capacitor app
- set the compile, minimum, and target SDK versions to API level 34/21 as requested

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9771676a483329d3060c27c7e0efc