### PR TITLE
Use Capacitor Preferences for wallet storage

### DIFF
--- a/src/app/pages/wallet/wallet.page.ts
+++ b/src/app/pages/wallet/wallet.page.ts
@@ -153,7 +153,7 @@ export class WalletPage implements OnInit, OnDestroy {
   }
 
   async loadWalletInfo(): Promise<void> {
-    this.wallet = this.carteraService.getWalletInfo();
+    this.wallet = await this.carteraService.getWalletInfo();
     if (this.wallet?.address) {
       await this.refreshBalance(this.wallet.address);
       this.updateQrImage(this.wallet.address);


### PR DESCRIPTION
## Summary
- switch CarteraService to persist wallet data with Capacitor Preferences
- make wallet page load the wallet info asynchronously via the updated service

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9bb2111988332aaffe8191ce18382