### PR TITLE
Add Ionic home page for wallet management

### DIFF
--- a/src/app/pages/home/home.module.ts
+++ b/src/app/pages/home/home.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+
+import { HomePage } from './home.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: HomePage,
+  },
+];
+
+@NgModule({
+  imports: [CommonModule, IonicModule, ReactiveFormsModule, RouterModule.forChild(routes)],
+  declarations: [HomePage],
+})
+export class HomePageModule {}

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -1,0 +1,110 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Home</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Gestión de Cartera</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <p>Genera una nueva cartera para comenzar a recibir eCash.</p>
+      <ion-button
+        expand="block"
+        color="primary"
+        (click)="onCreateWallet()"
+        [disabled]="isCreatingWallet"
+      >
+        {{ isCreatingWallet ? 'Creando…' : 'Crear Cartera' }}
+      </ion-button>
+      <ion-text color="danger" *ngIf="errorMessage && !hasWallet">
+        <p class="error-text">{{ errorMessage }}</p>
+      </ion-text>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-card *ngIf="hasWallet">
+    <ion-card-header>
+      <ion-card-title>Información de la Cartera</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-item lines="none">
+        <ion-label class="label-title">Dirección</ion-label>
+      </ion-item>
+      <ion-item lines="none">
+        <ion-label class="address-label">{{ wallet?.address }}</ion-label>
+      </ion-item>
+
+      <ion-item lines="none" class="balance-row">
+        <ion-label class="label-title">Saldo</ion-label>
+        <ion-button
+          slot="end"
+          size="small"
+          fill="outline"
+          (click)="refreshBalance()"
+          [disabled]="isRefreshingBalance"
+        >
+          {{ isRefreshingBalance ? 'Actualizando…' : 'Actualizar Saldo' }}
+        </ion-button>
+      </ion-item>
+      <ion-item lines="none">
+        <ion-label>{{ formattedBalance }}</ion-label>
+      </ion-item>
+
+      <ion-button expand="block" color="secondary" (click)="openSendModal()">
+        Enviar
+      </ion-button>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-text color="danger" *ngIf="errorMessage && hasWallet">
+    <p class="error-text">{{ errorMessage }}</p>
+  </ion-text>
+
+  <ion-modal [isOpen]="isSendModalOpen" (didDismiss)="closeSendModal()">
+    <ng-template>
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Enviar XEC</ion-title>
+          <ion-buttons slot="end">
+            <ion-button (click)="closeSendModal()" [disabled]="isSending">Cerrar</ion-button>
+          </ion-buttons>
+        </ion-toolbar>
+      </ion-header>
+
+      <ion-content class="ion-padding">
+        <form [formGroup]="sendForm" (ngSubmit)="onSubmitSend()">
+          <ion-item>
+            <ion-label position="stacked">Dirección destino</ion-label>
+            <ion-input formControlName="destination" required></ion-input>
+          </ion-item>
+
+          <ion-item>
+            <ion-label position="stacked">Monto (XEC)</ion-label>
+            <ion-input
+              type="number"
+              min="0.000001"
+              step="0.000001"
+              formControlName="amount"
+              required
+            ></ion-input>
+          </ion-item>
+
+          <ion-text color="danger" *ngIf="sendErrorMessage">
+            <p class="error-text">{{ sendErrorMessage }}</p>
+          </ion-text>
+
+          <ion-button
+            expand="block"
+            type="submit"
+            [disabled]="sendForm.invalid || isSending"
+          >
+            {{ isSending ? 'Enviando…' : 'Enviar' }}
+          </ion-button>
+        </form>
+      </ion-content>
+    </ng-template>
+  </ion-modal>
+</ion-content>

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -1,0 +1,16 @@
+.error-text {
+  margin-top: 0.75rem;
+}
+
+.address-label {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.label-title {
+  font-weight: 600;
+}
+
+.balance-row {
+  align-items: center;
+}

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -1,0 +1,165 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Toast } from '@capacitor/toast';
+
+import { CarteraService, WalletInfo } from '../../services/cartera.service';
+import { SaldoService } from '../../services/saldo.service';
+import { EnviarService } from '../../services/enviar.service';
+
+@Component({
+  selector: 'app-home-page',
+  templateUrl: './home.page.html',
+  styleUrls: ['./home.page.scss'],
+})
+export class HomePage implements OnInit {
+  wallet: WalletInfo | null = null;
+  balance: number | null = null;
+  isLoadingWallet = false;
+  isCreatingWallet = false;
+  isRefreshingBalance = false;
+  isSendModalOpen = false;
+  isSending = false;
+  errorMessage = '';
+  sendErrorMessage = '';
+
+  readonly sendForm: FormGroup;
+
+  constructor(
+    private readonly carteraService: CarteraService,
+    private readonly saldoService: SaldoService,
+    private readonly enviarService: EnviarService,
+    formBuilder: FormBuilder,
+  ) {
+    this.sendForm = formBuilder.group({
+      destination: ['', Validators.required],
+      amount: [null, [Validators.required, Validators.min(0.000001)]],
+    });
+  }
+
+  async ngOnInit(): Promise<void> {
+    await this.loadWallet();
+  }
+
+  get hasWallet(): boolean {
+    return !!this.wallet?.address;
+  }
+
+  get formattedBalance(): string {
+    if (this.balance === null) {
+      return '--';
+    }
+
+    return `${this.saldoService.formatBalance(this.balance)} XEC`;
+  }
+
+  async loadWallet(): Promise<void> {
+    this.isLoadingWallet = true;
+    this.errorMessage = '';
+
+    try {
+      this.wallet = await this.carteraService.getWalletInfo();
+      if (this.wallet?.address) {
+        await this.refreshBalance();
+      } else {
+        this.balance = null;
+      }
+    } catch (error) {
+      this.errorMessage = this.resolveErrorMessage(error);
+    } finally {
+      this.isLoadingWallet = false;
+    }
+  }
+
+  async onCreateWallet(): Promise<void> {
+    this.isCreatingWallet = true;
+    this.errorMessage = '';
+
+    try {
+      this.wallet = await this.carteraService.createWallet();
+      await this.refreshBalance();
+      await Toast.show({ text: 'Cartera creada correctamente.' });
+    } catch (error) {
+      this.errorMessage = this.resolveErrorMessage(error);
+    } finally {
+      this.isCreatingWallet = false;
+    }
+  }
+
+  async refreshBalance(): Promise<void> {
+    if (!this.wallet?.address) {
+      return;
+    }
+
+    this.isRefreshingBalance = true;
+    this.errorMessage = '';
+
+    try {
+      this.balance = await this.saldoService.getBalance(this.wallet.address);
+    } catch (error) {
+      this.errorMessage = this.resolveErrorMessage(error);
+    } finally {
+      this.isRefreshingBalance = false;
+    }
+  }
+
+  openSendModal(): void {
+    this.sendForm.reset({ destination: '', amount: null });
+    this.sendErrorMessage = '';
+    this.isSendModalOpen = true;
+  }
+
+  closeSendModal(): void {
+    this.isSendModalOpen = false;
+  }
+
+  async onSubmitSend(): Promise<void> {
+    if (!this.wallet?.mnemonic) {
+      this.sendErrorMessage = 'Debes crear una cartera antes de enviar fondos.';
+      return;
+    }
+
+    if (this.sendForm.invalid) {
+      this.sendForm.markAllAsTouched();
+      return;
+    }
+
+    const destination = String(this.sendForm.value.destination ?? '').trim();
+    const amount = Number(this.sendForm.value.amount);
+
+    if (!destination) {
+      this.sendErrorMessage = 'La dirección de destino es obligatoria.';
+      return;
+    }
+
+    if (!Number.isFinite(amount) || amount <= 0) {
+      this.sendErrorMessage = 'El monto debe ser mayor que cero.';
+      return;
+    }
+
+    this.isSending = true;
+    this.sendErrorMessage = '';
+
+    try {
+      const txid = await this.enviarService.sendTransaction(
+        { mnemonic: this.wallet.mnemonic, address: this.wallet.address },
+        destination,
+        amount,
+      );
+      await Toast.show({ text: `Transacción enviada: ${txid}` });
+      this.closeSendModal();
+      await this.refreshBalance();
+    } catch (error) {
+      this.sendErrorMessage = this.resolveErrorMessage(error);
+    } finally {
+      this.isSending = false;
+    }
+  }
+
+  private resolveErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return String(error ?? 'Ocurrió un error desconocido.');
+  }
+}

--- a/src/app/pages/tabs/tabs-routing.module.ts
+++ b/src/app/pages/tabs/tabs-routing.module.ts
@@ -9,6 +9,11 @@ const routes: Routes = [
     component: TabsPage,
     children: [
       {
+        path: 'home',
+        loadChildren: () =>
+          import('../home/home.module').then((m) => m.HomePageModule),
+      },
+      {
         path: 'wallet',
         loadChildren: () =>
           import('../wallet/wallet.module').then((m) => m.WalletPageModule),
@@ -27,7 +32,7 @@ const routes: Routes = [
       },
       {
         path: '',
-        redirectTo: 'wallet',
+        redirectTo: 'home',
         pathMatch: 'full',
       },
     ],

--- a/src/app/pages/tabs/tabs.page.ts
+++ b/src/app/pages/tabs/tabs.page.ts
@@ -7,6 +7,10 @@ import { Component } from '@angular/core';
       <ion-router-outlet></ion-router-outlet>
 
       <ion-tab-bar slot="bottom">
+        <ion-tab-button tab="home" [routerLink]="['/tabs/home']">
+          <ion-label>Home</ion-label>
+        </ion-tab-button>
+
         <ion-tab-button tab="wallet" [routerLink]="['/tabs/wallet']">
           <ion-label>Wallet</ion-label>
         </ion-tab-button>


### PR DESCRIPTION
## Summary
- create a new Home page that lets the user create a wallet, view its address and balance, and initiate transfers with Ionic UI components
- wire the Home page to CarteraService, SaldoService, and EnviarService to handle wallet creation, balance refresh, and sending funds with toast feedback
- expose the Home page via a new tab route and tab button in the existing tabs layout

## Testing
- npm run build *(fails: ionic command not available in environment)*
- npx ng build *(fails: tsconfig.json has an empty files list in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bbff7d2c8332a738444d1d8f52e6