### PR TITLE
Add configuration to guard debug runtime classpath copy consumption

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,13 @@ buildscript {
         google()
         mavenCentral()
     }
+    configurations {
+        all {
+            if (name.contains("debugRuntimeClasspathCopy")) {
+                canBeConsumed = false
+            }
+        }
+    }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.2'
         classpath 'com.google.gms:google-services:4.4.2'


### PR DESCRIPTION
## Summary
- add a configurations block to disable consumption of the debugRuntimeClasspathCopy configuration in the Android buildscript

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dabd70d4408332a66439b8c127ac4a