### PR TITLE
Enable BuildConfig and non-transitive R for Android build

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,4 +4,6 @@
 
 org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=true
 android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable generation of BuildConfig in the Android build
- configure Android to use a non-transitive R class and ensure Jetifier remains enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac73aac18833286a9312e8d3e341e