### PR TITLE
Fix debugRuntimeClasspathCopy Gradle configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,6 +34,13 @@ android {
     }
 }
 
+configurations {
+    debugRuntimeClasspathCopy {
+        canBeResolved = true
+        canBeConsumed = false
+    }
+}
+
 repositories {
     google()
     mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,13 +3,6 @@ buildscript {
         google()
         mavenCentral()
     }
-    configurations {
-        all {
-            if (name.contains("debugRuntimeClasspathCopy")) {
-                canBeConsumed = false
-            }
-        }
-    }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10"


### PR DESCRIPTION
## Summary
- remove the global workaround that modified any debugRuntimeClasspathCopy configuration
- explicitly define the debugRuntimeClasspathCopy configuration in the app module with the required attributes

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac7b309808332afc90c1de910c645