### PR TITLE
Ensure android settings exclude React Native plugin

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = "RMZWallet"
+rootProject.name = 'RMZWallet'
 
 include ':app'
 


### PR DESCRIPTION
## Summary
- ensure `android/settings.gradle` no longer references the React Native Gradle plugin
- normalize the root project name declaration while keeping only the Capacitor/Ionic modules

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae7d1bdec83329fbd00047958c51a