### PR TITLE
chore: clean up Android buildscript dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,8 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10"
-        classpath 'com.google.gms:google-services:4.4.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the unused Google services classpath from the Android buildscript
- align the Kotlin Gradle plugin version with the requested 1.9.0 release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daea2696bc8332ab8dd2fcf3a9ae4b