### PR TITLE
Add cleanup script for React Native artifacts

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo "🧹 Limpiando rastros de React Native..."
+npm uninstall react-native-gradle-plugin --save-dev
+rm -rf node_modules package-lock.json
+rm -rf android/.gradle android/build android/app/build
+echo "✅ React Native gradle plugin eliminado."
+echo "Ejecuta ahora: npm install && npx cap sync android"


### PR DESCRIPTION
## Summary
- add a cleanup.sh utility script at the repository root to remove React Native build artifacts and reinstall dependencies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daeb1c52a883329f24b272f0222fcb