### PR TITLE
Use double quotes for Gradle classpath configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
+        classpath "com.android.tools.build:gradle:8.1.1"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0"
     }
 }
 


### PR DESCRIPTION
## Summary
- update `android/build.gradle` to use double quotes for Gradle classpath entries and confirm only Android and Kotlin plugins are declared

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf103e1e08332887a58a454497d96