### PR TITLE
Update Android dependencies to use project Capacitor modules

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,7 +54,8 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.6.1"
     implementation "androidx.coordinatorlayout:coordinatorlayout:1.2.0"
     implementation "androidx.core:core-splashscreen:1.0.1"
-    implementation "com.getcapacitor:capacitor-android:7.0.0"
+    implementation project(":capacitor-android")
+    implementation project(":capacitor-cordova-android-plugins")
     testImplementation "junit:junit:4.13.2"
     androidTestImplementation "androidx.test.ext:junit:1.1.5"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"


### PR DESCRIPTION
## Summary
- replace the Capacitor Android dependency with the local project reference
- add the Capacitor Cordova Android plugins project to the app dependencies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf619b808833299784a3614e862a4