### PR TITLE
Simplify Gradle properties for Android build

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,9 +1,4 @@
-# Project-wide Gradle settings.
-# For more details on how to configure your build environment visit
-# https://docs.gradle.org/current/userguide/build_environment.html
-
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 android.useAndroidX=true
-android.defaults.buildfeatures.buildconfig=true
-android.nonTransitiveRClass=true
 android.enableJetifier=true
+kotlin.code.style=official


### PR DESCRIPTION
## Summary
- replace React Native specific Gradle configuration with standard Android properties
- update JVM memory settings to 4GB and align Kotlin formatting property

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dafc5c56a08332bc4dcd8bf36c8f3f