### PR TITLE
Add PWA support to RMZ Wallet

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -20,13 +20,20 @@
             "assets": [
               "src/favicon.txt",
               "src/assets",
-              "src/global.scss"
+              "src/global.scss",
+              "src/manifest.webmanifest"
             ],
             "styles": [],
             "scripts": []
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "optimization": {
                 "scripts": true,
                 "styles": {
@@ -39,6 +46,8 @@
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true,
+              "serviceWorker": true,
+              "ngswConfigPath": "ngsw-config.json",
               "budgets": [
                 {
                   "type": "initial",

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "./node_modules/@angular/service-worker/config/schema.json",
+  "index": "/index.html",
+  "assetGroups": [
+    {
+      "name": "app",
+      "installMode": "prefetch",
+      "resources": {
+        "files": [
+          "/favicon.ico",
+          "/index.html",
+          "/*.css",
+          "/*.js"
+        ]
+      }
+    },
+    {
+      "name": "assets",
+      "installMode": "lazy",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/assets/**",
+          "/manifest.webmanifest"
+        ]
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/platform-browser": "^17.3.12",
         "@angular/platform-browser-dynamic": "^17.3.12",
         "@angular/router": "^17.3.12",
+        "@angular/service-worker": "^17.3.12",
         "@capacitor/android": "^7.4.3",
         "@capacitor/core": "^7.4.3",
         "@capacitor/preferences": "^7.0.2",
@@ -1137,6 +1138,25 @@
         "@angular/core": "17.3.12",
         "@angular/platform-browser": "17.3.12",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/service-worker": {
+      "version": "17.3.12",
+      "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-17.3.12.tgz",
+      "integrity": "sha512-Y83+oTZ2XPO7P2Yok78JNlXDDXbP7Qr+HN6ifpPXWmUS4MwFEyXByCl3Hlz9VMxnrKvPYWvzHKWfT0S20XZsvA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "bin": {
+        "ngsw-config": "ngsw-config.js"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "17.3.12",
+        "@angular/core": "17.3.12"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@angular/platform-browser": "^17.3.12",
     "@angular/platform-browser-dynamic": "^17.3.12",
     "@angular/router": "^17.3.12",
+    "@angular/service-worker": "^17.3.12",
     "@capacitor/android": "^7.4.3",
     "@capacitor/core": "^7.4.3",
     "@capacitor/preferences": "^7.0.2",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <ion-app>
+      <ion-router-outlet></ion-router-outlet>
+    </ion-app>
+  `,
+})
+export class AppComponent {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouteReuseStrategy } from '@angular/router';
+import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
+import { ServiceWorkerModule } from '@angular/service-worker';
+
+import { AppComponent } from './app.component';
+import { AppRoutingModule } from './app-routing.module';
+import { environment } from '../environments/environment';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [
+    BrowserModule,
+    IonicModule.forRoot(),
+    AppRoutingModule,
+    ServiceWorkerModule.register('ngsw-worker.js', {
+      enabled: environment.production,
+    }),
+  ],
+  providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true,
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false,
+};

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <title>RMZ Wallet</title>
     <base href="/" />
+    <link rel="manifest" href="manifest.webmanifest" />
   </head>
   <body>
     <app-root></app-root>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,13 @@
-/**
- * Placeholder entry point for Angular-style builds.
- * Replace with a proper bootstrap once the web UI is migrated to Angular.
- */
-if (typeof window !== 'undefined') {
-  console.log('RMZ Wallet production build placeholder loaded.');
+import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
 }
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));

--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -1,0 +1,8 @@
+{
+  "name": "RMZ Wallet",
+  "short_name": "RMZWallet",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#12181f",
+  "theme_color": "#12181f"
+}


### PR DESCRIPTION
## Summary
- add Angular service worker support with a proper AppModule bootstrap and environment configuration
- include the RMZ Wallet web manifest and service worker config in the Angular build
- register the manifest link and add the @angular/service-worker dependency required for PWA support

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e06b0087488332809a3cb0b6c15796