### PR TITLE
feat(storage): mark transactions as sent

### DIFF
--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -29,6 +29,19 @@ export class StorageService {
     txStore.put(tx);
   }
 
+  markAsSent(txid: string) {
+    const txStore = this.db.transaction('transactions', 'readwrite').objectStore('transactions');
+    const getReq = txStore.get(txid);
+    getReq.onsuccess = () => {
+      const tx = getReq.result;
+      if (tx) {
+        tx.pending = false;
+        tx.sentAt = Date.now();
+        txStore.put(tx);
+      }
+    };
+  }
+
   async getAllTxs(): Promise<any[]> {
     return new Promise((resolve) => {
       const txStore = this.db.transaction('transactions', 'readonly').objectStore('transactions');


### PR DESCRIPTION
## Summary
- add StorageService.markAsSent to update pending and sentAt fields for stored transactions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e158f1054c833281014c179ca73323