### PR TITLE
Add BLE devices management page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,6 +8,11 @@ const routes: Routes = [
       import('./pages/tabs/tabs.module').then((m) => m.TabsPageModule),
   },
   {
+    path: 'ble-devices',
+    loadChildren: () =>
+      import('./pages/ble-devices/ble-devices.module').then((m) => m.BleDevicesPageModule),
+  },
+  {
     path: '',
     redirectTo: 'tabs',
     pathMatch: 'full',

--- a/src/app/pages/ble-devices/ble-devices.module.ts
+++ b/src/app/pages/ble-devices/ble-devices.module.ts
@@ -1,0 +1,13 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { IonicModule } from '@ionic/angular';
+
+import { BleDevicesPage } from './ble-devices.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, FormsModule, RouterModule.forChild([{ path: '', component: BleDevicesPage }])],
+  declarations: [BleDevicesPage],
+})
+export class BleDevicesPageModule {}

--- a/src/app/pages/ble-devices/ble-devices.page.html
+++ b/src/app/pages/ble-devices/ble-devices.page.html
@@ -1,0 +1,36 @@
+<ion-header>
+  <ion-toolbar color="dark">
+    <ion-title>Dispositivos Cercanos</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="scan()">
+        <ion-icon name="bluetooth-outline"></ion-icon>
+        Escanear
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item *ngFor="let device of devices" (click)="connect(device)">
+      <ion-icon slot="start" name="phone-portrait-outline"></ion-icon>
+      <ion-label>
+        <h2>{{ device.name || 'Sin nombre' }}</h2>
+        <p>{{ device.deviceId }}</p>
+      </ion-label>
+      <ion-badge color="success" *ngIf="device.connected">Conectado</ion-badge>
+    </ion-item>
+  </ion-list>
+
+  <ion-card *ngIf="connectedDevice">
+    <ion-card-header>
+      <ion-card-title>Enviar XEC a {{ connectedDevice.name }}</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-item>
+        <ion-input type="number" placeholder="Cantidad" [(ngModel)]="amount"></ion-input>
+      </ion-item>
+      <ion-button expand="block" color="primary" (click)="send()">Enviar</ion-button>
+    </ion-card-content>
+  </ion-card>
+</ion-content>

--- a/src/app/pages/ble-devices/ble-devices.page.scss
+++ b/src/app/pages/ble-devices/ble-devices.page.scss
@@ -1,0 +1,14 @@
+ion-card {
+  margin: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+}
+
+ion-badge {
+  font-size: 0.8em;
+}
+
+ion-item {
+  --background: #121212;
+  color: #fff;
+}

--- a/src/app/pages/ble-devices/ble-devices.page.ts
+++ b/src/app/pages/ble-devices/ble-devices.page.ts
@@ -1,0 +1,121 @@
+import { Component, OnDestroy } from '@angular/core';
+import type { BleDevice } from '@capacitor-community/bluetooth-le';
+import { Toast } from '@capacitor/toast';
+
+import { BleService } from '../../services/ble.service';
+
+interface UiBleDevice {
+  deviceId: string;
+  name?: string | null;
+  connected?: boolean;
+  [key: string]: unknown;
+}
+
+@Component({
+  selector: 'app-ble-devices',
+  templateUrl: './ble-devices.page.html',
+  styleUrls: ['./ble-devices.page.scss'],
+})
+export class BleDevicesPage implements OnDestroy {
+  devices: UiBleDevice[] = [];
+  connectedDevice: UiBleDevice | null = null;
+  amount = 0;
+
+  private discoveredDevices = new Map<string, UiBleDevice>();
+
+  constructor(private readonly ble: BleService) {}
+
+  ngOnDestroy(): void {
+    this.devices = [];
+    this.connectedDevice = null;
+    this.discoveredDevices.clear();
+    void this.ble.stop();
+  }
+
+  async scan(): Promise<void> {
+    this.devices = [];
+    this.connectedDevice = null;
+    this.discoveredDevices.clear();
+
+    await this.ble.init();
+    await Toast.show({ text: 'Buscando dispositivos BLE...' });
+
+    try {
+      await this.ble.scanAndConnect({
+        autoConnect: false,
+        onDeviceDiscovered: (device) => {
+          this.upsertDevice(device);
+        },
+      });
+    } catch (error) {
+      console.error('No fue posible iniciar el escaneo BLE.', error);
+      await Toast.show({ text: 'No fue posible iniciar el escaneo BLE.' });
+    }
+  }
+
+  async connect(device: UiBleDevice): Promise<void> {
+    try {
+      const connected = await this.ble.connect(device.deviceId);
+      this.markConnected(connected);
+    } catch (error) {
+      console.error('No fue posible conectar con el dispositivo BLE.', error);
+      await Toast.show({ text: 'No fue posible conectar con el dispositivo BLE.' });
+    }
+  }
+
+  async send(): Promise<void> {
+    if (!this.amount || !this.connectedDevice) {
+      await Toast.show({ text: 'Introduce cantidad y selecciona un dispositivo' });
+      return;
+    }
+
+    const target =
+      (typeof this.connectedDevice.address === 'string' && this.connectedDevice.address.length > 0
+        ? this.connectedDevice.address
+        : this.connectedDevice.deviceId);
+
+    try {
+      await this.ble.sendTx(target, this.amount);
+      await Toast.show({ text: 'Transacción enviada vía BLE.' });
+    } catch (error) {
+      console.error('No fue posible enviar la transacción vía BLE.', error);
+      await Toast.show({ text: 'No fue posible enviar la transacción vía BLE.' });
+    }
+  }
+
+  private upsertDevice(device: BleDevice): void {
+    const existing = this.discoveredDevices.get(device.deviceId);
+    const mapped: UiBleDevice = {
+      ...existing,
+      ...device,
+      connected: existing?.connected ?? false,
+    };
+    this.discoveredDevices.set(device.deviceId, mapped);
+    this.devices = Array.from(this.discoveredDevices.values());
+  }
+
+  private markConnected(device: BleDevice): void {
+    const stored = this.discoveredDevices.get(device.deviceId) ?? {
+      deviceId: device.deviceId,
+      name: device.name,
+    };
+
+    const updated: UiBleDevice = {
+      ...stored,
+      ...device,
+      connected: true,
+    };
+
+    this.discoveredDevices.set(device.deviceId, updated);
+
+    for (const [id, value] of this.discoveredDevices.entries()) {
+      if (id === device.deviceId) {
+        continue;
+      }
+      this.discoveredDevices.set(id, { ...value, connected: false });
+    }
+
+    this.devices = Array.from(this.discoveredDevices.values());
+    this.connectedDevice = updated;
+  }
+}


### PR DESCRIPTION
## Summary
- add a BLE devices page with a scan list and send controls
- extend the BLE service with manual discovery and explicit connect helpers
- register the BLE devices route in the application router

## Testing
- npm run lint *(fails: ESLint couldn't find eslint.config.*)*

------
https://chatgpt.com/codex/tasks/task_e_68e1639220188332a2f7e0bc745fefcf