### PR TITLE
Add BLE transfers entry to main menu

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,49 @@
+<ion-app>
+  <ion-split-pane contentId="main-content">
+    <ion-menu contentId="main-content" type="overlay">
+      <ion-header>
+        <ion-toolbar color="primary">
+          <ion-title>RMZ Wallet</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content>
+        <ion-list>
+          <ion-menu-toggle auto-hide="false">
+            <ion-item routerLink="/tabs/home" routerDirection="root">
+              <ion-icon slot="start" name="home-outline"></ion-icon>
+              <ion-label>Inicio</ion-label>
+            </ion-item>
+          </ion-menu-toggle>
+          <ion-menu-toggle auto-hide="false">
+            <ion-item routerLink="/tabs/wallet" routerDirection="root">
+              <ion-icon slot="start" name="wallet-outline"></ion-icon>
+              <ion-label>Cartera</ion-label>
+            </ion-item>
+          </ion-menu-toggle>
+          <ion-menu-toggle auto-hide="false">
+            <ion-item routerLink="/tabs/transactions" routerDirection="root">
+              <ion-icon slot="start" name="list-outline"></ion-icon>
+              <ion-label>Transacciones</ion-label>
+            </ion-item>
+          </ion-menu-toggle>
+          <ion-menu-toggle auto-hide="false">
+            <ion-item routerLink="/tabs/settings" routerDirection="root">
+              <ion-icon slot="start" name="settings-outline"></ion-icon>
+              <ion-label>Configuración</ion-label>
+            </ion-item>
+          </ion-menu-toggle>
+          <ion-menu-toggle auto-hide="false">
+            <ion-item routerLink="/ble-devices" routerDirection="root">
+              <ion-icon slot="start" name="bluetooth-outline"></ion-icon>
+              <ion-label>Transferencias BLE</ion-label>
+            </ion-item>
+          </ion-menu-toggle>
+        </ion-list>
+      </ion-content>
+    </ion-menu>
+
+    <div class="ion-page" id="main-content">
+      <ion-router-outlet></ion-router-outlet>
+    </div>
+  </ion-split-pane>
+</ion-app>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,11 +5,7 @@ import { SyncService } from './services/sync.service';
 
 @Component({
   selector: 'app-root',
-  template: `
-    <ion-app>
-      <ion-router-outlet></ion-router-outlet>
-    </ion-app>
-  `,
+  templateUrl: './app.component.html',
 })
 export class AppComponent implements OnInit {
   constructor(


### PR DESCRIPTION
## Summary
- move the root component template into an external HTML file so it can host the application menu
- extend the root menu with navigation links, including a new "Transferencias BLE" entry

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e166cd3fdc8332a491fc51d0f37123