### PR TITLE
Add Bluetooth connection card to wallet page

### DIFF
--- a/src/app/pages/wallet/wallet.page.html
+++ b/src/app/pages/wallet/wallet.page.html
@@ -54,10 +54,17 @@
         Buscar Peers
       </ion-button>
 
+    </ion-card-content>
+  </ion-card>
+
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Conexión Bluetooth</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
       <ion-button expand="block" color="success" (click)="connectBLE()">
         Conectar dispositivo BLE
       </ion-button>
-
       <ion-button expand="block" color="primary" (click)="sendBLE()">
         Enviar mensaje BLE
       </ion-button>


### PR DESCRIPTION
## Summary
- move the BLE action buttons into their own card on the wallet page
- add a dedicated Bluetooth connection section with connect and send actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e179d13f5c833281e078cce4ceafe7