### PR TITLE
Enable notification permission request on init

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -19,14 +19,10 @@ export class AppComponent implements OnInit {
     setTimeout(() => this.pwa.showInstallPrompt(), 5000);
     void this.enviarService.processPendingTransactions();
 
-    if (typeof window !== 'undefined' && 'Notification' in window) {
-      Notification.requestPermission()
-        .then((result) => {
-          console.info(`Permiso notificaciones: ${result}`);
-        })
-        .catch((error) => {
-          console.error('Permiso notificaciones: error', error);
-        });
+    if ('Notification' in window) {
+      Notification.requestPermission().then((result) => {
+        console.log('🔔 Permiso notificaciones:', result);
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- request the browser notification permission when the app component initializes
- log the notification permission result with an emoji to match the desired format

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e17b84ec008332b59faefc94b0e84d