### PR TITLE
Add BLE transaction form to wallet page

### DIFF
--- a/src/app/pages/wallet/wallet.page.html
+++ b/src/app/pages/wallet/wallet.page.html
@@ -73,6 +73,25 @@
 
   <ion-card>
     <ion-card-header>
+      <ion-card-title>Enviar por BLE</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-item>
+        <ion-label position="stacked">Dirección destino</ion-label>
+        <ion-input [(ngModel)]="toAddr" placeholder="ecash:..."></ion-input>
+      </ion-item>
+      <ion-item>
+        <ion-label position="stacked">Monto (XEC)</ion-label>
+        <ion-input type="number" [(ngModel)]="amount"></ion-input>
+      </ion-item>
+      <ion-button expand="block" color="primary" (click)="sendTxBLE()">
+        Enviar TX BLE
+      </ion-button>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-card>
+    <ion-card-header>
       <ion-card-title>Enviar</ion-card-title>
     </ion-card-header>
     <ion-card-content>


### PR DESCRIPTION
## Summary
- add a dedicated BLE transaction form to the wallet page
- bind BLE form inputs to the existing component properties
- provide a submit button that calls the BLE transaction sender

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e184843f3c8332927442ff439a73a3