### PR TITLE
Add online listener to resend pending transaction

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,5 +24,21 @@ export class AppComponent implements OnInit {
         console.log('🔔 Permiso notificaciones:', result);
       });
     }
+
+    window.addEventListener('online', async () => {
+      const pending = localStorage.getItem('pendingTx');
+      if (pending) {
+        const data = JSON.parse(pending);
+        const res = await fetch('https://chronik.e.cash/xec-mainnet/tx', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ hex: data.raw }),
+        });
+        if (res.ok) {
+          console.log('✅ TX enviada tras reconexión');
+          localStorage.removeItem('pendingTx');
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add an online event listener in the app component to resend pending transactions after a reconnection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1877f20fc8332bdf76d83f1f4b61a