### PR TITLE
feat: add local transaction history page

### DIFF
--- a/src/app/pages/transactions/transactions.page.html
+++ b/src/app/pages/transactions/transactions.page.html
@@ -2,78 +2,44 @@
   <ion-toolbar color="dark">
     <ion-title>Historial</ion-title>
     <ion-buttons slot="end">
-      <ion-button (click)="syncNow()" [disabled]="loading">
-        <ion-icon name="sync-outline"></ion-icon>
-      </ion-button>
-      <ion-button color="danger" (click)="clear()">
-        <ion-icon name="trash-outline"></ion-icon>
+      <ion-button (click)="load()" fill="clear">
+        <ion-icon name="refresh-outline"></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>
 
 <ion-content class="ion-padding">
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>Transacciones BLE</ion-card-title>
-      <ion-card-subtitle>Historial local</ion-card-subtitle>
-    </ion-card-header>
-    <ion-card-content>
-      <ion-list *ngIf="bleTxs.length; else noBleTxs">
-        <ion-item *ngFor="let tx of bleTxs">
-          <ion-icon [name]="txTypeIcon(tx.type)" slot="start" [color]="tx.type === 'sent' ? 'primary' : 'success'"></ion-icon>
-          <ion-label>
-            <h2>{{ txTypeLabel(tx.type) }} • {{ tx.amount | number:'1.2-2' }} XEC</h2>
-            <p>De: {{ tx.from }}</p>
-            <p>Para: {{ tx.to }}</p>
-            <p>{{ tx.timestamp | date:'medium' }}</p>
-          </ion-label>
-          <ion-badge [color]="statusColor(tx.status)">{{ statusLabel(tx.status) }}</ion-badge>
-        </ion-item>
-      </ion-list>
+  <ion-refresher slot="fixed" (ionRefresh)="load(); $event.target.complete()">
+    <ion-refresher-content></ion-refresher-content>
+  </ion-refresher>
 
-      <ng-template #noBleTxs>
-        <ion-text color="medium">
-          <p>No hay transacciones BLE registradas.</p>
-        </ion-text>
-      </ng-template>
-
-      <ion-button
-        *ngIf="bleTxs.length"
-        expand="block"
-        fill="outline"
-        color="medium"
-        (click)="clearBleHistory()"
-      >
-        Limpiar historial BLE
-      </ion-button>
-    </ion-card-content>
+  <ion-card *ngIf="txs.length; else empty">
+    <ion-list>
+      <ion-item lines="full" *ngFor="let tx of txs">
+        <ion-icon
+          slot="start"
+          [name]="tx.type === 'sent' ? 'arrow-up-circle-outline' : 'arrow-down-circle-outline'"
+          [color]="tx.type === 'sent' ? 'danger' : 'success'"
+        ></ion-icon>
+        <ion-label>
+          <h2>{{ tx.amount | number:'1.2-6' }} XEC</h2>
+          <p>{{ tx.type === 'sent' ? 'Enviada' : 'Recibida' }} • {{ tx.timestamp | date:'medium' }}</p>
+          <p>De: {{ tx.from }}</p>
+          <p>Para: {{ tx.to }}</p>
+        </ion-label>
+        <ion-badge [color]="getColor(tx.status)">{{ tx.status | titlecase }}</ion-badge>
+      </ion-item>
+    </ion-list>
   </ion-card>
 
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>Historial en cadena</ion-card-title>
-      <ion-card-subtitle>Sincronizado con Chronik</ion-card-subtitle>
-    </ion-card-header>
-    <ion-card-content>
-      <ion-list *ngIf="txs.length; else noTxs">
-        <ion-item *ngFor="let tx of txs">
-          <ion-label>
-            <h2>{{ tx.txid | slice:0:12 }}...</h2>
-            <p>{{ tx.amount }} XEC</p>
-            <p>{{ tx.time * 1000 | date:'medium' }}</p>
-          </ion-label>
-          <ion-badge color="{{ tx.confirmed ? 'success' : 'warning' }}">
-            {{ tx.confirmed ? 'Confirmada' : 'Pendiente' }}
-          </ion-badge>
-        </ion-item>
-      </ion-list>
-
-      <ng-template #noTxs>
-        <ion-text color="medium">
-          <p>No hay transacciones registradas.</p>
-        </ion-text>
-      </ng-template>
-    </ion-card-content>
-  </ion-card>
+  <ng-template #empty>
+    <ion-card>
+      <ion-card-content class="empty">
+        <ion-icon name="hourglass-outline"></ion-icon>
+        <h2>No hay transacciones registradas</h2>
+        <p>El historial se actualizará cuando envíes o recibas transacciones desde el dispositivo.</p>
+      </ion-card-content>
+    </ion-card>
+  </ng-template>
 </ion-content>

--- a/src/app/pages/transactions/transactions.page.scss
+++ b/src/app/pages/transactions/transactions.page.scss
@@ -1,3 +1,17 @@
 ion-badge {
   margin-left: auto;
 }
+
+ion-card-content.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+  color: var(--ion-color-medium);
+}
+
+ion-card-content.empty ion-icon {
+  font-size: 3rem;
+  color: var(--ion-color-medium);
+}

--- a/src/app/pages/transactions/transactions.page.ts
+++ b/src/app/pages/transactions/transactions.page.ts
@@ -1,85 +1,30 @@
 import { Component, OnInit } from '@angular/core';
-import { TransactionsService } from '../../services/transactions.service';
-import { WalletService } from '../../services/wallet.service';
-import { StoredTx, TxStorageService } from '../../services/tx-storage.service';
+import { TxStorageService, StoredTx } from '../../services/tx-storage.service';
 
 @Component({
   selector: 'app-transactions',
   templateUrl: './transactions.page.html',
-  styleUrls: ['./transactions.page.scss'],
+  styleUrls: ['./transactions.page.scss']
 })
 export class TransactionsPage implements OnInit {
-  txs: any[] = [];
-  bleTxs: StoredTx[] = [];
-  loading = false;
+  txs: StoredTx[] = [];
 
-  constructor(
-    private txService: TransactionsService,
-    private wallet: WalletService,
-    private readonly txStorage: TxStorageService,
-  ) {}
+  constructor(private store: TxStorageService) {}
 
-  async ngOnInit() {
-    this.txs = await this.txService.getAll();
-    this.loadBleTxs();
+  ngOnInit() {
+    this.load();
   }
 
-  ionViewWillEnter() {
-    this.loadBleTxs();
+  load() {
+    this.txs = this.store.getAll();
   }
 
-  async syncNow() {
-    this.loading = true;
-    const addr = this.wallet?.address;
-    if (addr) this.txs = await this.txService.sync(addr);
-    this.loading = false;
-  }
-
-  async clear() {
-    await this.txService.clear();
-    this.txs = [];
-  }
-
-  clearBleHistory() {
-    this.txStorage.clear();
-    this.loadBleTxs();
-  }
-
-  statusLabel(status: StoredTx['status']): string {
+  getColor(status: string): string {
     switch (status) {
-      case 'pending':
-        return 'Pendiente';
-      case 'signed':
-        return 'Firmada';
-      case 'broadcasted':
-        return 'Retransmitida';
-      default:
-        return status;
+      case 'pending': return 'warning';
+      case 'signed': return 'medium';
+      case 'broadcasted': return 'success';
+      default: return 'dark';
     }
-  }
-
-  statusColor(status: StoredTx['status']): string {
-    switch (status) {
-      case 'pending':
-        return 'warning';
-      case 'signed':
-        return 'medium';
-      case 'broadcasted':
-        return 'success';
-      default:
-        return 'medium';
-    }
-  }
-
-  txTypeIcon(type: StoredTx['type']): string {
-    return type === 'sent' ? 'arrow-up-circle-outline' : 'arrow-down-circle-outline';
-  }
-
-  txTypeLabel(type: StoredTx['type']): string {
-    return type === 'sent' ? 'Enviada' : 'Recibida';
-  }
-
-  private loadBleTxs() {
-    this.bleTxs = this.txStorage.getAll();
   }
 }


### PR DESCRIPTION
## Summary
- replace the transactions page logic to read stored transactions from `TxStorageService`
- render a refreshed card list with status badges and icons for each transaction type
- add styling and an empty state message for the transaction history view

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68e18dbb40cc8332bac85d73346ecafd