### PR TITLE
Add transactions history button to wallet page

### DIFF
--- a/src/app/pages/wallet/wallet.page.html
+++ b/src/app/pages/wallet/wallet.page.html
@@ -54,6 +54,10 @@
         Buscar Peers
       </ion-button>
 
+      <ion-button expand="block" color="light" routerLink="/transactions">
+        Ver historial de transacciones
+      </ion-button>
+
     </ion-card-content>
   </ion-card>
 


### PR DESCRIPTION
## Summary
- add a light-styled button on the wallet page that links to the transactions history view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e19786c2fc8332b982b2198d3e696f