### PR TITLE
Subscribe transactions page to tx stream

### DIFF
--- a/src/app/pages/transactions/transactions.page.ts
+++ b/src/app/pages/transactions/transactions.page.ts
@@ -1,22 +1,26 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { TxStorageService, StoredTx } from '../../services/tx-storage.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-transactions',
   templateUrl: './transactions.page.html',
   styleUrls: ['./transactions.page.scss']
 })
-export class TransactionsPage implements OnInit {
+export class TransactionsPage implements OnInit, OnDestroy {
   txs: StoredTx[] = [];
+  sub?: Subscription;
 
   constructor(private store: TxStorageService) {}
 
   ngOnInit() {
-    this.load();
+    this.sub = this.store.tx$.subscribe(data => {
+      this.txs = data;
+    });
   }
 
-  load() {
-    this.txs = this.store.getAll();
+  ngOnDestroy() {
+    this.sub?.unsubscribe();
   }
 
   getColor(status: string): string {
@@ -26,5 +30,9 @@ export class TransactionsPage implements OnInit {
       case 'broadcasted': return 'success';
       default: return 'dark';
     }
+  }
+
+  clearAll() {
+    this.store.clear();
   }
 }


### PR DESCRIPTION
## Summary
- subscribe the transactions page to the storage service observable and maintain a live list
- manage the subscription lifecycle on init and destroy to avoid leaks
- expose a clear action through the service to empty the transaction history

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e198af1e38833295259f2eb7d2f72e