### PR TITLE
Add fade-in animation to transactions list

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouteReuseStrategy } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
 import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
@@ -13,6 +14,7 @@ import { environment } from '../environments/environment';
   declarations: [AppComponent],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     IonicModule.forRoot(),
     HttpClientModule,
     AppRoutingModule,

--- a/src/app/pages/transactions/transactions.page.html
+++ b/src/app/pages/transactions/transactions.page.html
@@ -6,7 +6,7 @@
 
 <ion-content color="dark">
   <ion-list *ngIf="txs.length > 0; else noTx">
-    <ion-item *ngFor="let tx of txs" lines="full">
+    <ion-item *ngFor="let tx of txs" lines="full" [@fadeIn]>
       <ion-label>
         <h2>
           {{ tx.type === 'sent' ? '📤 Enviada' : '📥 Recibida' }}

--- a/src/app/pages/transactions/transactions.page.ts
+++ b/src/app/pages/transactions/transactions.page.ts
@@ -1,11 +1,20 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
+import { trigger, transition, style, animate } from '@angular/animations';
 import { TxStorageService, StoredTx } from '../../services/tx-storage.service';
 import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-transactions',
   templateUrl: './transactions.page.html',
-  styleUrls: ['./transactions.page.scss']
+  styleUrls: ['./transactions.page.scss'],
+  animations: [
+    trigger('fadeIn', [
+      transition(':enter', [
+        style({ opacity: 0 }),
+        animate('400ms ease-out', style({ opacity: 1 }))
+      ])
+    ])
+  ]
 })
 export class TransactionsPage implements OnInit, OnDestroy {
   txs: StoredTx[] = [];


### PR DESCRIPTION
## Summary
- add a fade-in animation trigger to transaction list items for smoother entry transitions
- enable Angular browser animations support in the app module

## Testing
- `npm install` *(fails: peer dependency conflict between eslint 9.x and @angular-eslint/builder 17.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e19a783e288332bb03859993997bab