### PR TITLE
Expand StoredTx status model

### DIFF
--- a/src/app/pages/transactions/transactions.page.ts
+++ b/src/app/pages/transactions/transactions.page.ts
@@ -36,9 +36,13 @@ export class TransactionsPage implements OnInit, OnDestroy {
     switch (status) {
       case 'pending': return 'warning';
       case 'signed': return 'medium';
+      case 'queued': return 'tertiary';
+      case 'broadcasting': return 'medium';
       case 'broadcasted': return 'success';
+      case 'confirming': return 'warning';
       case 'confirmed': return 'success';
       case 'failed': return 'danger';
+      case 'cancelled': return 'medium';
       default: return 'dark';
     }
   }

--- a/src/app/services/tx-ble.service.ts
+++ b/src/app/services/tx-ble.service.ts
@@ -66,6 +66,7 @@ export class TxBLEService {
         timestamp,
         raw: rawHex,
         txid: txid ?? undefined,
+        context: 'ble',
       };
 
       this.store.save(storedTx);
@@ -113,6 +114,7 @@ export class TxBLEService {
         timestamp: new Date().toISOString(),
         raw: txData.raw,
         txid: computedTxid ?? undefined,
+        context: 'ble',
       });
 
       console.log('📥 TX recibida por BLE:', txData);


### PR DESCRIPTION
## Summary
- extend the StoredTx model with richer lifecycle metadata, including additional statuses, optional context, and history tracking
- ensure TxStorageService normalizes history updates and exposes helpers for status updates with reasons and confirmations
- tag BLE-originated transactions with their source context and update the transaction list coloring for new statuses

## Testing
- npm run lint *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e19d9f7e5c8332ade6e92c740e0559