### PR TITLE
Add glow animation for pending transactions

### DIFF
--- a/src/app/pages/transactions/transactions.page.html
+++ b/src/app/pages/transactions/transactions.page.html
@@ -6,7 +6,7 @@
 
 <ion-content color="dark">
   <ion-list *ngIf="txs.length > 0; else noTx">
-    <ion-item *ngFor="let tx of txs" lines="full" [@fadeIn]>
+    <ion-item *ngFor="let tx of txs" lines="full" [@fadeIn] [ngClass]="{'new-tx': tx.status === 'pending'}">
       <ion-label>
         <h2>
           {{ tx.type === 'sent' ? '📤 Enviada' : '📥 Recibida' }}

--- a/src/app/pages/transactions/transactions.page.scss
+++ b/src/app/pages/transactions/transactions.page.scss
@@ -15,3 +15,19 @@ ion-card-content.empty ion-icon {
   font-size: 3rem;
   color: var(--ion-color-medium);
 }
+
+.new-tx {
+  animation: glow 1s ease-out;
+}
+
+@keyframes glow {
+  0% {
+    background-color: #00ffc31a;
+  }
+  50% {
+    background-color: #00ffc355;
+  }
+  100% {
+    background-color: transparent;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS animation to highlight pending transactions in the list
- apply a conditional class to transaction items when their status is pending

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1bb86824483328217faee97785663