### PR TITLE
Add notification settings service

### DIFF
--- a/src/app/services/notification-settings.service.ts
+++ b/src/app/services/notification-settings.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NotificationSettingsService {
+  private settingsKey = 'rmz_notify_settings';
+  private defaults = {
+    ble: true,
+    network: true,
+    sound: true,
+    visual: true
+  };
+
+  getSettings() {
+    const stored = localStorage.getItem(this.settingsKey);
+    return stored ? JSON.parse(stored) : this.defaults;
+  }
+
+  save(settings: any) {
+    localStorage.setItem(this.settingsKey, JSON.stringify(settings));
+  }
+
+  toggle(key: keyof typeof this.defaults) {
+    const current = this.getSettings();
+    current[key] = !current[key];
+    this.save(current);
+  }
+}


### PR DESCRIPTION
## Summary
- add a notification settings service to manage BLE, network, sound, and visual preference toggles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e28281c81c83329cea54020214dcbf