### PR TITLE
feat: add notifications settings page

### DIFF
--- a/src/app/pages/settings/notifications/notifications.module.ts
+++ b/src/app/pages/settings/notifications/notifications.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { RouterModule, Routes } from '@angular/router';
+
+import { NotificationsPage } from './notifications.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: NotificationsPage,
+  },
+];
+
+@NgModule({
+  imports: [CommonModule, FormsModule, IonicModule, RouterModule.forChild(routes)],
+  declarations: [NotificationsPage],
+})
+export class NotificationsPageModule {}

--- a/src/app/pages/settings/notifications/notifications.page.html
+++ b/src/app/pages/settings/notifications/notifications.page.html
@@ -1,0 +1,20 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/tabs/settings"></ion-back-button>
+    </ion-buttons>
+    <ion-title>Notificaciones</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-list inset="true">
+    <ion-item *ngFor="let option of notificationOptions" lines="inset">
+      <ion-label>
+        <h2>{{ option.title }}</h2>
+        <p>{{ option.description }}</p>
+      </ion-label>
+      <ion-toggle slot="end" color="primary"></ion-toggle>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/pages/settings/notifications/notifications.page.scss
+++ b/src/app/pages/settings/notifications/notifications.page.scss
@@ -1,0 +1,13 @@
+ion-item {
+  --inner-padding-end: 0;
+}
+
+ion-label h2 {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+ion-label p {
+  margin: 0;
+  color: var(--ion-color-medium);
+}

--- a/src/app/pages/settings/notifications/notifications.page.ts
+++ b/src/app/pages/settings/notifications/notifications.page.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-notifications',
+  templateUrl: './notifications.page.html',
+  styleUrls: ['./notifications.page.scss'],
+})
+export class NotificationsPage {
+  public readonly notificationOptions = [
+    {
+      title: 'Alertas de transacciones',
+      description:
+        'Recibe avisos cuando se acrediten o debiten fondos de tu billetera.',
+    },
+    {
+      title: 'Recordatorios',
+      description:
+        'Mantente al día con recordatorios para tareas importantes dentro de la app.',
+    },
+    {
+      title: 'Novedades del producto',
+      description:
+        'Sé la primera persona en enterarte sobre nuevas funciones y mejoras.',
+    },
+  ];
+}

--- a/src/app/pages/settings/settings.page.ts
+++ b/src/app/pages/settings/settings.page.ts
@@ -10,9 +10,17 @@ import { Component } from '@angular/core';
     </ion-header>
 
     <ion-content class="ion-padding">
-      <p>
-        Aquí podrás personalizar la aplicación. Por ahora este es un texto placeholder
-        mientras definimos las opciones de configuración.
+      <ion-list inset="true">
+        <ion-item routerLink="notifications" detail>
+          <ion-label>
+            <h2>Notificaciones</h2>
+            <p>Personaliza cómo y cuándo recibir avisos de la aplicación.</p>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+
+      <p class="ion-text-center ion-margin-top ion-text-wrap">
+        Muy pronto encontrarás más opciones para adaptar RMZ Wallet a tus necesidades.
       </p>
     </ion-content>
   `,

--- a/src/app/pages/tabs/tabs-routing.module.ts
+++ b/src/app/pages/tabs/tabs-routing.module.ts
@@ -27,8 +27,20 @@ const routes: Routes = [
       },
       {
         path: 'settings',
-        loadChildren: () =>
-          import('../settings/settings.module').then((m) => m.SettingsPageModule),
+        children: [
+          {
+            path: '',
+            loadChildren: () =>
+              import('../settings/settings.module').then((m) => m.SettingsPageModule),
+          },
+          {
+            path: 'notifications',
+            loadChildren: () =>
+              import('../settings/notifications/notifications.module').then(
+                (m) => m.NotificationsPageModule,
+              ),
+          },
+        ],
       },
       {
         path: '',


### PR DESCRIPTION
## Summary
- add a dedicated notifications settings page with placeholder toggles and content
- link to the notifications page from the settings screen and configure nested routing under the settings tab

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68e283a932a083329960575dec86bb90