### PR TITLE
feat: update notifications page logic

### DIFF
--- a/src/app/pages/settings/notifications/notifications.page.ts
+++ b/src/app/pages/settings/notifications/notifications.page.ts
@@ -1,26 +1,29 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { NotificationService } from 'src/app/services/notification.service';
+import { NotificationSettingsService } from 'src/app/services/notification-settings.service';
 
 @Component({
   selector: 'app-notifications',
   templateUrl: './notifications.page.html',
   styleUrls: ['./notifications.page.scss'],
 })
-export class NotificationsPage {
-  public readonly notificationOptions = [
-    {
-      title: 'Alertas de transacciones',
-      description:
-        'Recibe avisos cuando se acrediten o debiten fondos de tu billetera.',
-    },
-    {
-      title: 'Recordatorios',
-      description:
-        'Mantente al día con recordatorios para tareas importantes dentro de la app.',
-    },
-    {
-      title: 'Novedades del producto',
-      description:
-        'Sé la primera persona en enterarte sobre nuevas funciones y mejoras.',
-    },
-  ];
+export class NotificationsPage implements OnInit {
+  settings: any = {};
+
+  constructor(
+    private notify: NotificationService,
+    private settingsService: NotificationSettingsService
+  ) {}
+
+  ngOnInit() {
+    this.settings = this.settingsService.getSettings();
+  }
+
+  save() {
+    this.settingsService.save(this.settings);
+  }
+
+  testNotification() {
+    this.notify.show('🔔 Prueba de notificación', 'Esta es una notificación de ejemplo.');
+  }
 }


### PR DESCRIPTION
## Summary
- update the notifications settings page to load and save user preferences through the notification settings service
- add support for sending a test notification using the notification service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28606aed48332a937e9f6177b93c3