### PR TITLE
Respect notification toggles for Chronik and BLE services

### DIFF
--- a/src/app/services/chronik.service.ts
+++ b/src/app/services/chronik.service.ts
@@ -3,6 +3,7 @@ import { ChronikClient } from 'chronik-client';
 
 import { TxStorageService } from './tx-storage.service';
 import { NotificationService } from './notification.service';
+import { NotificationSettingsService } from './notification-settings.service';
 
 type ChronikWsClient = ReturnType<ChronikClient['ws']>;
 
@@ -25,6 +26,7 @@ export class ChronikService {
   constructor(
     private readonly store: TxStorageService,
     private readonly notify: NotificationService,
+    private readonly settingsService: NotificationSettingsService,
   ) {
     this.ensureWsClient();
   }
@@ -128,12 +130,14 @@ export class ChronikService {
 
     console.log('📦 TX actualizada vía WS:', txid, msg.type);
 
-    if (msg.type === 'AddedToMempool') {
+    const settings = this.settingsService.getSettings();
+
+    if (msg.type === 'AddedToMempool' && settings.network) {
       this.notify.show('💸 Nueva TX detectada', 'Se ha recibido una transacción pendiente');
       this.store.updateStatusByTxid(txid, 'broadcasted');
     }
 
-    if (msg.type === 'Confirmed') {
+    if (msg.type === 'Confirmed' && settings.network) {
       this.notify.show('✅ Transacción confirmada', 'Una transacción ha sido incluida en bloque');
       this.store.updateStatusByTxid(txid, 'confirmed');
     }

--- a/src/app/services/tx-ble.service.ts
+++ b/src/app/services/tx-ble.service.ts
@@ -4,6 +4,7 @@ import { Wallet } from 'ecash-wallet';
 import { BLEService } from './ble.service';
 import { ChronikService } from './chronik.service';
 import { NotificationService } from './notification.service';
+import { NotificationSettingsService } from './notification-settings.service';
 import { StoredTx, TxStorageService } from './tx-storage.service';
 
 @Injectable({
@@ -17,6 +18,7 @@ export class TxBLEService {
     private readonly store: TxStorageService,
     private readonly chronik: ChronikService,
     private readonly notify: NotificationService,
+    private readonly settingsService: NotificationSettingsService,
   ) {}
 
   private generateId(): string {
@@ -100,7 +102,8 @@ export class TxBLEService {
   async receiveAndBroadcast(data: unknown): Promise<void> {
     try {
       const txData = JSON.parse(String(data));
-      if (txData.type !== 'tx') {
+      const settings = this.settingsService.getSettings();
+      if (txData.type !== 'tx' || !settings.ble) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- gate Chronik websocket notifications and updates behind the network notification toggle
- ensure BLE transaction handling only runs when the BLE notification toggle is enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28b9fee34833298ce7cd8a8e97d1e