### PR TITLE
Refactor wallet services to use Chronik-backed factories

### DIFF
--- a/src/app/services/cartera.service.ts
+++ b/src/app/services/cartera.service.ts
@@ -16,12 +16,12 @@ export interface WalletInfo {
 
 const WORDS = ENGLISH_WORDLIST;
 const STORAGE_KEY = 'rmz_wallet';
-const CHRONIK_URL = 'https://chronik.e.cash';
+const CHRONIK_URL = 'https://chronik.e.cash/xec-mainnet';
 
 @Injectable({ providedIn: 'root' })
 export class CarteraService {
   private cachedWallet: WalletInfo | null = null;
-  private readonly chronikClient = new ChronikClient([CHRONIK_URL]);
+  private readonly chronikClient = new ChronikClient(CHRONIK_URL);
 
   constructor(private readonly offlineStorage: OfflineStorageService) {}
 


### PR DESCRIPTION
## Summary
- align wallet, saldo, and cartera services with the Chronik-backed ecash-wallet API
- create shared Chronik clients and hex parsing helpers for wallet instantiation
- ensure wallet clients are synced before sending transactions or fetching balances

## Testing
- npm run lint *(fails: ESLint 9 requires a migrated eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ac07d43c8332b40695c37c772143