### PR TITLE
Migrate wallet services to ecash-wallet static constructors

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -23,6 +23,8 @@
               "src/global.scss",
               "src/manifest.webmanifest"
             ],
+            "serviceWorker": true,
+            "ngswConfigPath": "ngsw-config.json",
             "styles": [],
             "scripts": []
           },

--- a/src/app/services/ble.service.ts
+++ b/src/app/services/ble.service.ts
@@ -217,7 +217,7 @@ export class BLEService {
     this.rxCharacteristic = null;
   }
 
-  private async notify(message: string): Promise<void> {
+  public async notify(message: string): Promise<void> {
     if (typeof window === 'undefined' || !('Notification' in window)) {
       console.info(`[BLE] ${message}`);
       return;

--- a/src/app/services/tx-ble.service.ts
+++ b/src/app/services/tx-ble.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { ChronikClient } from 'chronik-client';
 import { Wallet } from 'ecash-wallet';
 
 import { BLEService } from './ble.service';
@@ -6,6 +7,8 @@ import { ChronikService } from './chronik.service';
 import { NotificationService } from './notification.service';
 import { NotificationSettingsService } from './notification-settings.service';
 import { StoredTx, TxStorageService } from './tx-storage.service';
+
+const chronik = new ChronikClient('https://chronik.e.cash');
 
 @Injectable({
   providedIn: 'root',
@@ -31,8 +34,8 @@ export class TxBLEService {
   }
 
   async initWallet(mnemonic: string): Promise<void> {
-    this.wallet = await Wallet.fromMnemonic(mnemonic);
-    const address = this.wallet.address();
+    this.wallet = await Wallet.fromMnemonic(mnemonic, chronik);
+    const address = this.wallet.address;
     console.log('✅ Cartera inicializada:', address);
     void this.chronik.subscribeToAddress(address);
     void this.chronik.syncAll();
@@ -46,7 +49,7 @@ export class TxBLEService {
 
     try {
       const txId = this.generateId();
-      const fromAddress = this.wallet.address();
+      const fromAddress = this.wallet.address;
       const timestamp = new Date().toISOString();
 
       const sats = Math.floor(amountXec * 100);


### PR DESCRIPTION
## Summary
- replace direct Wallet instantiation with async Wallet.fromPrivateKey across enviar, saldo, and wallet services while standardizing the Chronik client
- update BLE transaction service to use the new Wallet.fromMnemonic signature and expose BLE notifications publicly
- enable service worker configuration in the default Angular build options

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ae3ed6a48332b2e769c5b20a74db