### PR TITLE
fix: configure angular modules

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,10 +1,13 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouteReuseStrategy } from '@angular/router';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
+import { ServiceWorkerModule } from '@angular/service-worker';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
+import { environment } from '../environments/environment';
 
 @NgModule({
   declarations: [AppComponent],
@@ -12,9 +15,15 @@ import { AppRoutingModule } from './app-routing.module';
     BrowserModule,
     IonicModule.forRoot(),
     AppRoutingModule,
+    FormsModule,
+    ReactiveFormsModule,
+    ServiceWorkerModule.register('ngsw-worker.js', {
+      enabled: environment.production,
+    }),
   ],
   providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }],
   bootstrap: [AppComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  exports: [IonicModule, FormsModule],
 })
 export class AppModule {}


### PR DESCRIPTION
## Summary
- add Angular and Ionic modules required for application bootstrap
- enable service worker registration tied to the production environment
- export IonicModule and FormsModule for template bindings

## Testing
- npm run build *(fails: ionic command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5320fa63c8332aabce02c2cfba7a8