### PR TITLE
Refactor wallet services to use modern eCash APIs

### DIFF
--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -1,136 +1,39 @@
 import { Injectable } from '@angular/core';
-import { ChronikClient } from 'chronik-client';
 import { Wallet } from 'ecash-wallet';
+import { ChronikClient } from 'chronik-client';
 
-import type { WalletInfo } from './cartera.service';
-import { CarteraService } from './cartera.service';
-
-const SATS_PER_XEC = 100;
-
-@Injectable({ providedIn: 'root' })
+@Injectable({
+  providedIn: 'root'
+})
 export class WalletService {
-  private client: Wallet | null = null;
-  private walletInfo: WalletInfo | null = null;
-  private readonly chronik = new ChronikClient('https://chronik.e.cash');
+  private chronik: ChronikClient;
+  private wallet: Wallet | null = null;
 
-  constructor(private readonly carteraService: CarteraService) {
-    void this.ensureWalletInfo().catch(() => undefined);
+  constructor() {
+    this.chronik = new ChronikClient('https://chronik.e.cash/xec-mainnet');
   }
 
-  get address(): string | null {
-    if (this.client) {
-      const candidate = this.getWalletAddress(this.client);
-      if (candidate) {
-        return candidate;
-      }
-    }
-
-    return this.walletInfo?.address ?? null;
+  async loadFromMnemonic(mnemonic: string) {
+    this.wallet = await Wallet.fromMnemonic(mnemonic, this.chronik);
+    return this.wallet;
   }
 
-  private async ensureClient(): Promise<Wallet> {
-    const wallet = await this.ensureWalletInfo();
-
-    if (!this.client) {
-      const client = await Wallet.fromMnemonic(
-        this.normalizeMnemonic(wallet.mnemonic),
-        this.chronik,
-      );
-      this.client = client;
-
-      const derivedAddress = this.getWalletAddress(client);
-      if (derivedAddress && (!wallet.address || wallet.address !== derivedAddress)) {
-        this.walletInfo = { ...wallet, address: derivedAddress };
-      }
-    }
-
-    return this.client;
+  async getAddress(): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not initialized');
+    return this.wallet.getAddress();
   }
 
-  private async ensureWalletInfo(): Promise<WalletInfo> {
-    if (!this.walletInfo) {
-      const info = await this.carteraService.getWalletInfo();
-      if (!info) {
-        throw new Error('No se encontró una cartera configurada.');
-      }
-      if (!info.mnemonic) {
-        throw new Error('La cartera no contiene una frase mnemónica válida.');
-      }
-      this.walletInfo = info;
-    }
-
-    return this.walletInfo;
+  async getBalance(): Promise<number> {
+    if (!this.wallet) throw new Error('Wallet not initialized');
+    const utxos = await this.wallet.getUtxos();
+    const balance = utxos.reduce((sum, utxo) => sum + utxo.value, 0);
+    return balance / 100; // convertir satoshis a XEC
   }
 
-  async enviar(toAddress: string, amount: number): Promise<{ txid: string }> {
-    if (!Number.isFinite(amount) || amount <= 0) {
-      throw new Error('El monto a enviar debe ser mayor que cero.');
-    }
-
-    const client = await this.ensureClient();
-    const satsAmount = this.xecToSats(amount);
-
-    const tx = await client.createTx({
-      to: toAddress,
-      amount: satsAmount,
-    });
-
-    const broadcastResult = await client.broadcastTx(tx);
-    const txid = this.extractTxid(broadcastResult);
-
-    if (!txid) {
-      throw new Error('La transacción no devolvió un identificador.');
-    }
-
-    return { txid };
-  }
-
-  clearCache(): void {
-    this.client = null;
-    this.walletInfo = null;
-  }
-
-  private normalizeMnemonic(mnemonic: string): string {
-    return mnemonic
-      .trim()
-      .split(/\s+/u)
-      .map((word) => word.toLowerCase())
-      .join(' ');
-  }
-
-  private xecToSats(amount: number): number {
-    return Math.round(amount * SATS_PER_XEC);
-  }
-
-  private extractTxid(result: unknown): string | null {
-    if (typeof result === 'string') {
-      return result;
-    }
-
-    if (result && typeof result === 'object') {
-      const record = result as Record<string, unknown>;
-      const possibleKeys = ['txid', 'txId', 'id'];
-      for (const key of possibleKeys) {
-        const value = record[key];
-        if (typeof value === 'string' && value) {
-          return value;
-        }
-      }
-    }
-
-    return null;
-  }
-
-  private getWalletAddress(wallet: Wallet): string | null {
-    const getAddress = (wallet as { getAddress?: () => string }).getAddress;
-    if (typeof getAddress === 'function') {
-      const address = getAddress.call(wallet);
-      if (address) {
-        return address;
-      }
-    }
-
-    const legacyAddress = (wallet as { address?: string }).address;
-    return typeof legacyAddress === 'string' ? legacyAddress : null;
+  async createAndBroadcastTx(toAddress: string, amount: number) {
+    if (!this.wallet) throw new Error('Wallet not initialized');
+    const tx = await this.wallet.createTx({ to: toAddress, amount });
+    const txid = await this.wallet.broadcastTx(tx);
+    return txid;
   }
 }


### PR DESCRIPTION
## Summary
- replace the wallet service with an implementation based on the latest ecash-wallet and chronik-client APIs
- update the send service to share the same Chronik endpoint and simplified satoshi conversion handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e542b0ba98833296c80d8f0d38fe44