### PR TITLE
Ensure ReactiveFormsModule exported from AppModule

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,6 @@ import { environment } from '../environments/environment';
   providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }],
   bootstrap: [AppComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  exports: [IonicModule, FormsModule],
+  exports: [IonicModule, FormsModule, ReactiveFormsModule],
 })
 export class AppModule {}


### PR DESCRIPTION
## Summary
- export ReactiveFormsModule from the root AppModule alongside the existing forms and Ionic modules

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5779a751083328d9b5d6780657fd6