### PR TITLE
feat: add status bar component for connectivity indicators

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -43,6 +43,7 @@
     </ion-menu>
 
     <div class="ion-page" id="main-content">
+      <app-status-bar></app-status-bar>
       <ion-router-outlet></ion-router-outlet>
     </div>
   </ion-split-pane>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,9 +8,10 @@ import { ServiceWorkerModule } from '@angular/service-worker';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { environment } from '../environments/environment';
+import { StatusBarComponent } from './components/status-bar/status-bar.component';
 
 @NgModule({
-  declarations: [AppComponent],
+  declarations: [AppComponent, StatusBarComponent],
   imports: [
     BrowserModule,
     IonicModule.forRoot(),

--- a/src/app/components/status-bar/status-bar.component.html
+++ b/src/app/components/status-bar/status-bar.component.html
@@ -1,0 +1,17 @@
+<div class="status-bar">
+  <div class="status-item" [ngClass]="internetStatusClass" aria-live="polite">
+    <ion-icon [name]="internetIcon" aria-hidden="true"></ion-icon>
+    <div class="status-text">
+      <span class="status-label">Internet</span>
+      <span class="status-value">{{ internetStatusText }}</span>
+    </div>
+  </div>
+
+  <div class="status-item" [ngClass]="bleStatusClass" aria-live="polite">
+    <ion-icon [name]="bleIcon" aria-hidden="true"></ion-icon>
+    <div class="status-text">
+      <span class="status-label">BLE</span>
+      <span class="status-value">{{ bleStatusText }}</span>
+    </div>
+  </div>
+</div>

--- a/src/app/components/status-bar/status-bar.component.scss
+++ b/src/app/components/status-bar/status-bar.component.scss
@@ -1,0 +1,95 @@
+:host {
+  display: block;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: var(--ion-color-step-100, #1f1f1f);
+  padding: calc(env(safe-area-inset-top, 0px) + 0.25rem) 1rem 0.25rem;
+  box-shadow: 0 1px 0 rgba(var(--ion-color-step-400-rgb, 56, 56, 56), 0.35);
+}
+
+.status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.status-item {
+  flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(var(--ion-color-light-rgb, 244, 244, 244), 0.04);
+  color: var(--ion-color-light, #f4f5f8);
+  min-width: 0;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.status-item ion-icon {
+  font-size: 1.1rem;
+}
+
+.status-item--ok {
+  color: var(--ion-color-success, #2fdf75);
+}
+
+.status-item--ok ion-icon {
+  color: var(--ion-color-success, #2fdf75);
+}
+
+.status-item--warning {
+  color: var(--ion-color-warning, #ffc409);
+}
+
+.status-item--warning ion-icon {
+  color: var(--ion-color-warning, #ffc409);
+}
+
+.status-item--error {
+  color: var(--ion-color-danger, #eb445a);
+}
+
+.status-item--error ion-icon {
+  color: var(--ion-color-danger, #eb445a);
+}
+
+.status-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+  overflow: hidden;
+}
+
+.status-label {
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--ion-color-light-rgb, 244, 244, 244), 0.6);
+}
+
+.status-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: currentColor;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 480px) {
+  :host {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+
+  .status-bar {
+    gap: 0.5rem;
+  }
+
+  .status-item {
+    padding: 0.4rem 0.7rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable status bar component that monitors online status and BLE connectivity
- register the status bar in the app module and render it above the routed content
- style the bar with iconography and color cues for quick status recognition

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68e578bd3ca08332b22587344d256e45