### PR TITLE
Update status bar toolbar layout

### DIFF
--- a/src/app/components/status-bar/status-bar.component.html
+++ b/src/app/components/status-bar/status-bar.component.html
@@ -1,17 +1,18 @@
-<div class="status-bar">
-  <div class="status-item" [ngClass]="internetStatusClass" aria-live="polite">
-    <ion-icon [name]="internetIcon" aria-hidden="true"></ion-icon>
-    <div class="status-text">
-      <span class="status-label">Internet</span>
-      <span class="status-value">{{ internetStatusText }}</span>
+<ion-toolbar color="dark" class="status-bar" mode="md">
+  <div class="status-container">
+    <div class="network" [class.online]="isOnline" [class.offline]="!isOnline" aria-live="polite">
+      <ion-icon [name]="internetIcon" aria-hidden="true"></ion-icon>
+      <span>{{ isOnline ? 'Online' : 'Offline' }}</span>
     </div>
-  </div>
 
-  <div class="status-item" [ngClass]="bleStatusClass" aria-live="polite">
-    <ion-icon [name]="bleIcon" aria-hidden="true"></ion-icon>
-    <div class="status-text">
-      <span class="status-label">BLE</span>
-      <span class="status-value">{{ bleStatusText }}</span>
+    <div
+      class="ble"
+      [class.connected]="bleConnected"
+      [class.disconnected]="!bleConnected"
+      aria-live="polite"
+    >
+      <ion-icon [name]="bleIcon" aria-hidden="true"></ion-icon>
+      <span>{{ bleConnected ? bleDevice ?? 'BLE conectado' : 'BLE desconectado' }}</span>
     </div>
   </div>
-</div>
+</ion-toolbar>

--- a/src/app/components/status-bar/status-bar.component.scss
+++ b/src/app/components/status-bar/status-bar.component.scss
@@ -3,19 +3,28 @@
   position: sticky;
   top: 0;
   z-index: 1000;
-  background: var(--ion-color-step-100, #1f1f1f);
-  padding: calc(env(safe-area-inset-top, 0px) + 0.25rem) 1rem 0.25rem;
+}
+
+ion-toolbar.status-bar {
+  --background: var(--ion-color-step-100, #1f1f1f);
+  --color: var(--ion-color-light, #f4f5f8);
+  --padding-top: calc(env(safe-area-inset-top, 0px) + 0.35rem);
+  --padding-bottom: 0.35rem;
+  --padding-start: 1rem;
+  --padding-end: 1rem;
   box-shadow: 0 1px 0 rgba(var(--ion-color-step-400-rgb, 56, 56, 56), 0.35);
 }
 
-.status-bar {
+.status-container {
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
 }
 
-.status-item {
+.network,
+.ble {
   flex: 1 1 0;
   display: flex;
   align-items: center;
@@ -23,73 +32,46 @@
   padding: 0.45rem 0.9rem;
   border-radius: 999px;
   background: rgba(var(--ion-color-light-rgb, 244, 244, 244), 0.04);
-  color: var(--ion-color-light, #f4f5f8);
+  color: rgba(var(--ion-color-light-rgb, 244, 244, 244), 0.78);
   min-width: 0;
   transition: background 150ms ease, color 150ms ease;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
-.status-item ion-icon {
+.network ion-icon,
+.ble ion-icon {
   font-size: 1.1rem;
 }
 
-.status-item--ok {
+.network.online {
   color: var(--ion-color-success, #2fdf75);
 }
 
-.status-item--ok ion-icon {
+.network.offline {
+  color: var(--ion-color-danger, #eb445a);
+}
+
+.ble.connected {
   color: var(--ion-color-success, #2fdf75);
 }
 
-.status-item--warning {
-  color: var(--ion-color-warning, #ffc409);
-}
-
-.status-item--warning ion-icon {
-  color: var(--ion-color-warning, #ffc409);
-}
-
-.status-item--error {
-  color: var(--ion-color-danger, #eb445a);
-}
-
-.status-item--error ion-icon {
-  color: var(--ion-color-danger, #eb445a);
-}
-
-.status-text {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.1;
-  overflow: hidden;
-}
-
-.status-label {
-  font-size: 0.65rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(var(--ion-color-light-rgb, 244, 244, 244), 0.6);
-}
-
-.status-value {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: currentColor;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.ble.disconnected {
+  color: var(--ion-color-medium, #92949c);
 }
 
 @media (max-width: 480px) {
-  :host {
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
+  ion-toolbar.status-bar {
+    --padding-start: 0.75rem;
+    --padding-end: 0.75rem;
   }
 
-  .status-bar {
+  .status-container {
     gap: 0.5rem;
   }
 
-  .status-item {
+  .network,
+  .ble {
     padding: 0.4rem 0.7rem;
   }
 }

--- a/src/app/components/status-bar/status-bar.component.ts
+++ b/src/app/components/status-bar/status-bar.component.ts
@@ -45,28 +45,20 @@ export class StatusBarComponent implements OnInit, OnDestroy {
     return this.isOnline ? 'wifi' : 'cloud-offline';
   }
 
-  get internetStatusClass(): string {
-    return this.isOnline ? 'status-item--ok' : 'status-item--error';
-  }
-
-  get internetStatusText(): string {
-    return this.isOnline ? 'Conectado' : 'Sin conexión';
-  }
-
   get bleIcon(): string {
     return this.bleService.connectedDevice ? 'bluetooth' : 'bluetooth-outline';
   }
 
-  get bleStatusClass(): string {
-    return this.bleService.connectedDevice ? 'status-item--ok' : 'status-item--warning';
+  get bleConnected(): boolean {
+    return !!this.bleService.connectedDevice;
   }
 
-  get bleStatusText(): string {
-    if (this.bleService.connectedDevice) {
-      const name = this.bleService.connectedDevice.name ?? this.bleService.connectedDevice.localName;
-      return name && name.trim().length > 0 ? name : 'Conectado';
+  get bleDevice(): string | null {
+    if (!this.bleService.connectedDevice) {
+      return null;
     }
 
-    return 'Desconectado';
+    const name = this.bleService.connectedDevice.name ?? this.bleService.connectedDevice.localName;
+    return name && name.trim().length > 0 ? name : null;
   }
 }


### PR DESCRIPTION
## Summary
- refactor the status bar component to render within an ion-toolbar and simplify the network/BLE status text
- refresh the status bar styling for the new toolbar layout and state color treatments
- expose BLE connection helpers for the template to display device names when available

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68e57b794d888332bb7211c25acc90d4