### PR TITLE
Place status bar above router outlet

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,5 @@
 <ion-app>
+  <app-status-bar></app-status-bar>
   <ion-split-pane contentId="main-content">
     <ion-menu contentId="main-content" type="overlay">
       <ion-header>
@@ -43,7 +44,6 @@
     </ion-menu>
 
     <div class="ion-page" id="main-content">
-      <app-status-bar></app-status-bar>
       <ion-router-outlet></ion-router-outlet>
     </div>
   </ion-split-pane>


### PR DESCRIPTION
## Summary
- move the status bar component to render directly under the ion-app wrapper
- keep the existing split-pane layout while ensuring the status bar sits above the router outlet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57f92839c8332adcbf51c56519d7d