### PR TITLE
Simplify BLE devices page layout

### DIFF
--- a/src/app/pages/ble-devices/ble-devices.page.html
+++ b/src/app/pages/ble-devices/ble-devices.page.html
@@ -1,90 +1,40 @@
 <ion-header>
   <ion-toolbar color="dark">
     <ion-title>Dispositivos BLE</ion-title>
-    <ion-buttons slot="end">
-      <ion-button fill="outline" color="primary" (click)="startScan()" [disabled]="scanning || !isSupported">
-        <ion-icon slot="start" name="scan-circle-outline"></ion-icon>
-        {{ scanning ? 'Escaneando' : 'Escanear' }}
-        <ion-spinner *ngIf="scanning" slot="end" name="lines-small"></ion-spinner>
-      </ion-button>
-      <ion-button fill="clear" color="medium" (click)="stopScan()" *ngIf="scanning">
-        <ion-icon slot="start" name="stop-circle-outline"></ion-icon>
-        Detener
-      </ion-button>
-    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 
-<ion-content>
-  <section class="status" *ngIf="!isSupported">
-    <ion-icon name="alert-circle-outline"></ion-icon>
-    <p>El navegador o dispositivo no soporta Bluetooth Low Energy.</p>
-  </section>
-
-  <ion-card class="connection-card">
+<ion-content class="ion-padding">
+  <ion-card *ngIf="connectedDevice">
     <ion-card-header>
-      <ion-card-title>Estado de conexión</ion-card-title>
-      <ion-card-subtitle>{{ connectionStatus }}</ion-card-subtitle>
+      <ion-card-title>Conectado</ion-card-title>
+      <ion-card-subtitle>{{ connectedDevice.name }}</ion-card-subtitle>
     </ion-card-header>
     <ion-card-content>
-      <ng-container *ngIf="connectedDevice; else noDevice">
-        <div class="device-info">
-          <ion-icon name="bluetooth-outline"></ion-icon>
-          <div>
-            <h3>{{ connectedDevice?.name || 'Sin nombre' }}</h3>
-            <small>ID: {{ connectedDevice?.deviceId }}</small>
-          </div>
-        </div>
-        <ion-button expand="block" color="danger" (click)="disconnect()">
-          <ion-icon slot="start" name="log-out-outline"></ion-icon>
-          Desconectar
-        </ion-button>
-      </ng-container>
-      <ng-template #noDevice>
-        <p class="empty">No hay dispositivos conectados actualmente.</p>
-      </ng-template>
+      <p>ID: {{ connectedDevice.deviceId }}</p>
+      <ion-button color="danger" expand="block" (click)="disconnect()">Desconectar</ion-button>
     </ion-card-content>
   </ion-card>
 
-  <ion-list inset="true">
-    <ion-list-header lines="none">
-      <ion-label>Dispositivos disponibles</ion-label>
-      <ion-note slot="end" *ngIf="devices.length">{{ devices.length }} encontrados</ion-note>
-    </ion-list-header>
+  <ion-button expand="block" color="success" (click)="startScan()" [disabled]="scanning">
+    {{ scanning ? 'Buscando dispositivos...' : 'Buscar dispositivos BLE' }}
+  </ion-button>
 
-    <ion-item *ngFor="let device of devices" lines="inset" detail="false">
-      <ion-icon slot="start" name="hardware-chip-outline"></ion-icon>
+  <ion-list *ngIf="devices.length > 0">
+    <ion-item *ngFor="let device of devices">
       <ion-label>
-        <h2>{{ device.name || 'Sin nombre' }}</h2>
-        <p>{{ device.deviceId }}</p>
+        <h2>{{ device.name }}</h2>
+        <p>ID: {{ device.deviceId }}</p>
+        <p *ngIf="device.rssi">RSSI: {{ device.rssi }}</p>
       </ion-label>
-
-      <ion-chip color="tertiary" *ngIf="device.rssi !== undefined" slot="end">
-        <ion-icon name="bar-chart-outline"></ion-icon>
-        <ion-label>{{ device.rssi }} dBm</ion-label>
-      </ion-chip>
-
-      <ion-badge color="success" *ngIf="device.connected" slot="end">Conectado</ion-badge>
-
-      <ion-button
-        slot="end"
-        size="small"
-        [color]="device.connected ? 'danger' : 'primary'"
-        (click)="device.connected ? disconnect() : connect(device)"
-      >
-        <ion-icon slot="start" [name]="device.connected ? 'link-off-outline' : 'link-outline'"></ion-icon>
-        {{ device.connected ? 'Desconectar' : 'Conectar' }}
+      <ion-button slot="end" color="primary" (click)="connect(device)">
+        Conectar
       </ion-button>
     </ion-item>
   </ion-list>
 
-  <div class="empty" *ngIf="!devices.length && scanning">
-    <ion-spinner name="dots"></ion-spinner>
-    <p>Buscando dispositivos cercanos...</p>
-  </div>
+  <ion-text *ngIf="!devices.length && !scanning">
+    <p class="no-devices">No se detectaron dispositivos BLE cercanos.</p>
+  </ion-text>
 
-  <div class="empty" *ngIf="!devices.length && !scanning && isSupported">
-    <ion-icon name="bluetooth-outline"></ion-icon>
-    <p>Inicia un escaneo para encontrar dispositivos BLE cercanos.</p>
-  </div>
 </ion-content>

--- a/src/app/pages/ble-devices/ble-devices.page.scss
+++ b/src/app/pages/ble-devices/ble-devices.page.scss
@@ -1,103 +1,21 @@
 :host {
   ion-content {
-    --background: #0b0b0f;
-    color: #fff;
-  }
-}
-
-.status {
-  margin: 16px;
-  padding: 16px;
-  border-radius: 12px;
-  background: rgba(255, 87, 87, 0.1);
-  color: #ff8a80;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-
-  ion-icon {
-    font-size: 28px;
-  }
-}
-
-.connection-card {
-  margin: 16px;
-  background: rgba(255, 255, 255, 0.04);
-  backdrop-filter: blur(8px);
-
-  ion-card-title,
-  ion-card-subtitle {
-    color: #fff;
-  }
-
-  .device-info {
     display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 16px;
-
-    ion-icon {
-      font-size: 32px;
-      color: #46b2ff;
-    }
-
-    h3 {
-      margin: 0;
-      font-size: 1rem;
-      font-weight: 600;
-    }
-
-    small {
-      display: block;
-      color: rgba(255, 255, 255, 0.6);
-    }
+    flex-direction: column;
+    gap: 16px;
   }
+}
+
+ion-card {
+  --background: var(--ion-color-light, #fff);
 }
 
 ion-list {
   background: transparent;
 }
 
-ion-item {
-  --background: rgba(255, 255, 255, 0.04);
-  margin-bottom: 8px;
-  border-radius: 12px;
-
-  ion-icon {
-    color: #46b2ff;
-  }
-
-  h2 {
-    margin: 0;
-    font-weight: 600;
-    color: #fff;
-  }
-
-  p {
-    margin: 4px 0 0;
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.7);
-    word-break: break-all;
-  }
-}
-
-ion-chip {
-  margin-right: 8px;
-}
-
-.empty {
-  margin: 32px 16px;
-  padding: 24px;
+.no-devices {
+  margin-top: 24px;
   text-align: center;
-  color: rgba(255, 255, 255, 0.7);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: center;
-  justify-content: center;
-
-  ion-icon {
-    font-size: 40px;
-    color: #46b2ff;
-  }
+  color: var(--ion-color-medium, #666);
 }


### PR DESCRIPTION
## Summary
- streamline the BLE devices page template to show the connected device card, scan action, and list of discovered devices as requested
- simplify the accompanying styles to match the reduced layout and highlight the empty-state message

## Testing
- npx ionic serve --host=0.0.0.0 --port=8100 *(fails: The requested module '@angular/compiler' does not provide an export named 'BindingPipeType')*

------
https://chatgpt.com/codex/tasks/task_e_68e5955804848332bb2fe6ea73bb1457