### PR TITLE
Ensure service worker only registers when supported

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,9 @@ import { AppRoutingModule } from './app-routing.module';
 import { environment } from '../environments/environment';
 import { StatusBarComponent } from './components/status-bar/status-bar.component';
 
+const serviceWorkerEnabled =
+  environment.production && typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
+
 @NgModule({
   declarations: [AppComponent, StatusBarComponent],
   imports: [
@@ -19,7 +22,7 @@ import { StatusBarComponent } from './components/status-bar/status-bar.component
     FormsModule,
     ReactiveFormsModule,
     ServiceWorkerModule.register('ngsw-worker.js', {
-      enabled: environment.production,
+      enabled: serviceWorkerEnabled,
       registrationStrategy: 'registerWhenStable:30000',
     }),
   ],


### PR DESCRIPTION
## Summary
- guard the Angular service worker registration behind a runtime support check so it only attempts to register in production browsers
- keep the existing delayed registration strategy for stability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ab1312d083328d9f12ad0526db93