### PR TITLE
Enable service worker configuration for development builds

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -67,7 +67,9 @@
               "sourceMap": true,
               "vendorChunk": true,
               "extractLicenses": false,
-              "buildOptimizer": false
+              "buildOptimizer": false,
+              "serviceWorker": true,
+              "ngswConfigPath": "ngsw-config.json"
             }
           },
           "defaultConfiguration": "production"


### PR DESCRIPTION
## Summary
- ensure the Angular development build configuration enables the service worker and references the `ngsw-config.json`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5aeb9c53c833299f853476f4cf7ef