### PR TITLE
Refine RMZWallet onboarding with XolosArmy branding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,15 +8,18 @@ import BackupSeed from './routes/BackupSeed'
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Dashboard />} />
-      <Route path="/send" element={<SendRMZ />} />
-      <Route path="/receive" element={<Receive />} />
-      <Route path="/settings" element={<Settings />} />
-      <Route path="/onboarding" element={<Onboarding />} />
-      <Route path="/backup" element={<BackupSeed />} />
-      <Route path="*" element={<Navigate to="/onboarding" replace />} />
-    </Routes>
+    <div className="app-shell">
+      <div className="app-glow" aria-hidden />
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/send" element={<SendRMZ />} />
+        <Route path="/receive" element={<Receive />} />
+        <Route path="/settings" element={<Settings />} />
+        <Route path="/onboarding" element={<Onboarding />} />
+        <Route path="/backup" element={<BackupSeed />} />
+        <Route path="*" element={<Navigate to="/onboarding" replace />} />
+      </Routes>
+    </div>
   )
 }
 

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,23 @@
+import logo from '../assets/xolosarmy-logo-dark.png'
+
+function TopBar() {
+  return (
+    <div className="topbar">
+      <div className="brand">
+        <div className="brand-mark">
+          <img src={logo} alt="Logo XolosArmy" />
+        </div>
+        <div className="brand-copy">
+          <p className="brand-title">RMZWallet</p>
+          <p className="brand-subtitle">XolosArmy Network · eToken &amp; wallet on eCash (XEC)</p>
+        </div>
+      </div>
+      <div className="status-pill" aria-hidden>
+        <span className="dot" />
+        Seguridad en tu dispositivo
+      </div>
+    </div>
+  )
+}
+
+export default TopBar

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,22 @@
 :root {
-  font-family: 'Montserrat', 'Segoe UI', sans-serif;
+  --bg: #020617;
+  --bg-alt: #0b1120;
+  --panel: rgba(255, 255, 255, 0.03);
+  --panel-strong: rgba(247, 148, 77, 0.06);
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #f5f5f5;
+  --muted: #9fa6b2;
+  --accent: #d76823;
+  --accent-2: #f29a4a;
+  --teal: #39d0c2;
+  --radius-lg: 20px;
+  --radius-pill: 999px;
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+  font-family: 'Montserrat', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
   line-height: 1.6;
   font-weight: 400;
-  color: #e4eaf5;
-  background-color: #0b1224;
+  color: var(--text);
+  background-color: var(--bg);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -16,10 +29,10 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at 20% 20%, rgba(104, 82, 255, 0.2), transparent 35%),
-    radial-gradient(circle at 80% 0%, rgba(0, 219, 222, 0.25), transparent 30%),
-    #0b1224;
-  color: #e4eaf5;
+  background: radial-gradient(circle at 15% 20%, rgba(247, 148, 77, 0.14), transparent 30%),
+    radial-gradient(circle at 80% 0%, rgba(57, 208, 194, 0.14), transparent 25%),
+    linear-gradient(135deg, var(--bg), #050608 45%, #0b1120);
+  color: var(--text);
 }
 
 a {
@@ -27,67 +40,208 @@ a {
   text-decoration: none;
 }
 
-.page {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 48px 24px 64px;
+.app-shell {
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
 }
 
-.header {
+.app-glow {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 25% 15%, rgba(242, 154, 74, 0.12), transparent 35%),
+    radial-gradient(circle at 80% 10%, rgba(57, 208, 194, 0.12), transparent 35%);
+  filter: blur(50px);
+  opacity: 0.8;
+  z-index: 0;
+}
+
+.page {
+  position: relative;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+  z-index: 1;
+}
+
+.topbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 24px;
+  gap: 16px;
+  padding: 12px 16px;
+  margin-bottom: 28px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(120deg, rgba(215, 104, 35, 0.14), rgba(11, 17, 32, 0.95));
+  border: 1px solid rgba(215, 104, 35, 0.25);
+  box-shadow: var(--shadow);
 }
 
-.title {
-  font-size: 28px;
-  letter-spacing: 0.6px;
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.brand-mark {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: radial-gradient(circle at 30% 30%, rgba(242, 154, 74, 0.4), rgba(2, 6, 23, 0.9));
+  border: 1px solid rgba(242, 154, 74, 0.25);
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.35);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.brand-mark img {
+  width: 44px;
+  height: 44px;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 20px rgba(242, 154, 74, 0.25));
+}
+
+.brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.brand-title {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
   margin: 0;
+}
+
+.brand-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: var(--radius-pill);
+  background: rgba(57, 208, 194, 0.09);
+  border: 1px solid rgba(57, 208, 194, 0.3);
+  color: #c8fffa;
+  font-weight: 600;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+}
+
+.status-pill .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--teal);
+  box-shadow: 0 0 0 6px rgba(57, 208, 194, 0.12);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+.hero-copy {
+  padding: 28px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(2, 6, 23, 0.9), rgba(11, 17, 32, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0 0 8px;
+}
+
+.hero-title,
+.section-title {
+  margin: 0 0 10px;
+  font-size: 32px;
+  letter-spacing: 0.2px;
+}
+
+.lead {
+  margin: 0 0 20px;
+  color: #d3d8e4;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.hero-card {
+  padding: 28px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(160deg, rgba(215, 104, 35, 0.18), rgba(11, 17, 32, 0.95));
+  border: 1px solid rgba(215, 104, 35, 0.35);
+  box-shadow: var(--shadow);
+}
+
+.hero-badge {
+  display: inline-block;
+  padding: 8px 14px;
+  border-radius: var(--radius-pill);
+  background: rgba(242, 154, 74, 0.14);
+  color: #ffd1a3;
+  font-weight: 700;
+  margin: 6px 0 14px;
+}
+
+.hero-note {
+  color: #e9ded3;
+  margin: 0 0 18px;
+}
+
+.hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: var(--radius-pill);
+  background: rgba(242, 154, 74, 0.16);
+  color: #ffd8b6;
+  border: 1px solid rgba(215, 104, 35, 0.4);
+  font-weight: 600;
+}
+
+.pill-ghost {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
 }
 
 .subtitle {
   margin: 0;
-  color: #9fb0d4;
-}
-
-.card {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 16px;
-  padding: 20px;
-  margin-bottom: 16px;
-  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.35);
-}
-
-.cta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  border: none;
-  border-radius: 12px;
-  padding: 12px 16px;
-  background: linear-gradient(135deg, #6c5ce7, #00dbde);
-  color: #0b1224;
-  font-weight: 700;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
-}
-
-.cta:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.cta:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 30px rgba(0, 219, 222, 0.35);
-}
-
-.secondary {
-  background: rgba(255, 255, 255, 0.08);
-  color: #e4eaf5;
+  color: var(--muted);
 }
 
 .grid {
@@ -96,8 +250,79 @@ a {
   gap: 16px;
 }
 
-.muted {
-  color: #9fb0d4;
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+}
+
+.card-kicker {
+  color: var(--muted);
+  font-weight: 600;
+  margin: 0 0 6px;
+  letter-spacing: 0.4px;
+}
+
+.card h2 {
+  margin: 0 0 8px;
+}
+
+.card.highlight {
+  background: linear-gradient(145deg, rgba(57, 208, 194, 0.1), rgba(2, 6, 23, 0.85));
+  border-color: rgba(57, 208, 194, 0.3);
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  padding: 12px 18px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease, border-color 0.2s ease;
+}
+
+.cta.primary {
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  color: #0b0b0f;
+  box-shadow: 0 14px 32px rgba(215, 104, 35, 0.4);
+}
+
+.cta.outline {
+  background: transparent;
+  border-color: rgba(242, 154, 74, 0.6);
+  color: #ffd8b6;
+}
+
+.cta.ghost {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.cta:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.cta:not(:disabled):hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 16px;
 }
 
 label {
@@ -110,24 +335,38 @@ input,
 textarea {
   width: 100%;
   padding: 12px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  border: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.05);
-  color: #e4eaf5;
+  color: var(--text);
   font-size: 15px;
 }
 
 input:focus,
 textarea:focus {
-  outline: 2px solid #00dbde;
+  outline: 2px solid rgba(57, 208, 194, 0.6);
   border-color: transparent;
+  box-shadow: 0 8px 22px rgba(57, 208, 194, 0.15);
+}
+
+.address-box {
+  font-family: 'Source Code Pro', 'SFMono-Regular', monospace;
+  word-break: break-all;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 16px;
+  padding: 12px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+}
+
+.muted {
+  color: var(--muted);
 }
 
 .error {
   color: #ffb4b4;
   background: rgba(255, 94, 94, 0.12);
   border: 1px solid rgba(255, 94, 94, 0.35);
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 12px;
   margin-top: 10px;
 }
@@ -136,23 +375,27 @@ textarea:focus {
   color: #b9f6ca;
   background: rgba(51, 217, 178, 0.12);
   border: 1px solid rgba(51, 217, 178, 0.25);
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 12px;
   margin-top: 10px;
 }
 
-.actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-top: 16px;
+.onboarding-grid {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
-.address-box {
-  font-family: 'Source Code Pro', 'SFMono-Regular', monospace;
-  word-break: break-all;
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 12px;
-  padding: 12px;
-  border: 1px dashed rgba(255, 255, 255, 0.18);
+@media (max-width: 720px) {
+  .section-header {
+    flex-direction: column;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }

--- a/src/routes/BackupSeed.tsx
+++ b/src/routes/BackupSeed.tsx
@@ -2,6 +2,7 @@ import type { FormEvent } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useWallet } from '../context/WalletContext'
+import TopBar from '../components/TopBar'
 
 interface BackupState {
   password: string
@@ -58,10 +59,12 @@ function BackupSeed() {
 
   return (
     <div className="page">
-      <header className="header">
+      <TopBar />
+      <header className="section-header">
         <div>
-          <p className="subtitle">Respalda tu seed</p>
-          <h1 className="title">Sin seed, no hay $RMZ</h1>
+          <p className="eyebrow">Respalda tu seed</p>
+          <h1 className="section-title">Sin seed, no hay $RMZ</h1>
+          <p className="muted">Guarda tus 12 palabras como si fueran tu tesoro más valioso.</p>
         </div>
       </header>
 

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useWallet } from '../context/WalletContext'
+import TopBar from '../components/TopBar'
 
 function Dashboard() {
   const { address, balance, initialized, refreshBalances, loading, error } = useWallet()
@@ -14,10 +15,11 @@ function Dashboard() {
   if (!initialized) {
     return (
       <div className="page">
-        <h1 className="title">Bienvenido</h1>
+        <TopBar />
+        <h1 className="section-title">Bienvenido</h1>
         <p className="muted">Configura tu billetera para ver tus saldos.</p>
         <div className="actions">
-          <Link className="cta" to="/onboarding">
+          <Link className="cta primary" to="/onboarding">
             Ir a onboarding
           </Link>
         </div>
@@ -27,16 +29,18 @@ function Dashboard() {
 
   return (
     <div className="page">
-      <header className="header">
+      <TopBar />
+      <header className="section-header">
         <div>
-          <p className="subtitle">xolosArmy Wallet</p>
-          <h1 className="title">$RMZ es el protagonista</h1>
+          <p className="eyebrow">Panel principal</p>
+          <h1 className="section-title">Guardianía RMZ sobre eCash</h1>
+          <p className="muted">Saldos, gas y tu dirección protegida en una sola vista.</p>
         </div>
         <div className="actions">
-          <Link className="cta" to="/send">
+          <Link className="cta primary" to="/send">
             Enviar RMZ
           </Link>
-          <Link className="cta secondary" to="/receive">
+          <Link className="cta outline" to="/receive">
             Recibir
           </Link>
         </div>

--- a/src/routes/Onboarding.tsx
+++ b/src/routes/Onboarding.tsx
@@ -1,7 +1,8 @@
 import type { FormEvent } from 'react'
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useWallet } from '../context/WalletContext'
+import TopBar from '../components/TopBar'
 
 function Onboarding() {
   const navigate = useNavigate()
@@ -52,15 +53,46 @@ function Onboarding() {
 
   return (
     <div className="page">
-      <header className="header">
-        <div>
-          <p className="subtitle">Bienvenido a xolosArmy Wallet</p>
-          <h1 className="title">$RMZ en tu propio dispositivo</h1>
-        </div>
-      </header>
+      <TopBar />
 
-      <div className="grid">
-        <form className="card" onSubmit={handleCreate}>
+      <section className="hero">
+        <div className="hero-copy">
+          <p className="eyebrow">Bienvenido a RMZWallet</p>
+          <h1 className="hero-title">Tu templo seguro para XEC y el eToken RMZ</h1>
+          <p className="lead">
+            Configura tu cartera para ver tus saldos y mover XEC con seguridad. Explora tus tokens, NFTs y el
+            ecosistema XolosArmy desde una sola interfaz.
+          </p>
+          <div className="hero-actions">
+            <a className="cta primary" href="#crear">
+              Crear nueva cartera RMZWallet
+            </a>
+            <a className="cta outline" href="#importar">
+              Conectar cartera existente
+            </a>
+            <a className="cta ghost" href="#lectura">
+              Ver saldos de tokens y NFTs
+            </a>
+          </div>
+        </div>
+
+        <div className="hero-card">
+          <p className="muted">Cyber-aztec · XolosArmy Network</p>
+          <div className="hero-badge">Guardianía digital</div>
+          <p className="hero-note">
+            La seed y el cifrado viven solo en tu dispositivo. Usa un password local que recuerdes y respalda tu frase
+            de 12 palabras.
+          </p>
+          <div className="hero-stats">
+            <span className="pill">RMZ listo para eCash (XEC)</span>
+            <span className="pill pill-ghost">Modo lectura disponible</span>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid onboarding-grid">
+        <form id="crear" className="card" onSubmit={handleCreate}>
+          <p className="card-kicker">Nuevo templo</p>
           <h2>Crear billetera nueva</h2>
           <p className="muted">La seed se genera localmente y nunca sale de tu dispositivo.</p>
           <label htmlFor="new-password">Password/PIN local</label>
@@ -72,13 +104,14 @@ function Onboarding() {
             onChange={(e) => setPasswordNew(e.target.value)}
           />
           <div className="actions">
-            <button className="cta" type="submit" disabled={loading}>
+            <button className="cta primary" type="submit" disabled={loading}>
               Generar seed
             </button>
           </div>
         </form>
 
-        <form className="card" onSubmit={handleExisting}>
+        <form id="importar" className="card" onSubmit={handleExisting}>
+          <p className="card-kicker">Conectar</p>
           <h2>Usar billetera guardada</h2>
           <p className="muted">Ingresa el password/PIN con el que cifraste la seed.</p>
           <label htmlFor="existing-password">Password/PIN</label>
@@ -90,11 +123,24 @@ function Onboarding() {
             onChange={(e) => setPasswordExisting(e.target.value)}
           />
           <div className="actions">
-            <button className="cta secondary" type="submit" disabled={loading}>
+            <button className="cta outline" type="submit" disabled={loading}>
               Desbloquear
             </button>
           </div>
         </form>
+
+        <div id="lectura" className="card highlight">
+          <p className="card-kicker">Modo lectura</p>
+          <h2>Ver saldos de tokens y NFTs</h2>
+          <p className="muted">
+            Puedes entrar en modo solo lectura para revisar tu dirección, saldo RMZ y gas en XEC sin exponer tu seed.
+          </p>
+          <div className="actions">
+            <Link className="cta ghost" to="/">
+              Abrir vista de saldos
+            </Link>
+          </div>
+        </div>
       </div>
 
       {(localError || error) && <div className="error">{localError || error}</div>}

--- a/src/routes/Receive.tsx
+++ b/src/routes/Receive.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { useWallet } from '../context/WalletContext'
+import TopBar from '../components/TopBar'
 
 function Receive() {
   const { address, initialized } = useWallet()
@@ -7,10 +8,11 @@ function Receive() {
   if (!initialized) {
     return (
       <div className="page">
-        <h1 className="title">Configura tu billetera</h1>
+        <TopBar />
+        <h1 className="section-title">Configura tu billetera</h1>
         <p className="muted">Ve al onboarding para generar o desbloquear tu seed.</p>
         <div className="actions">
-          <Link className="cta" to="/onboarding">
+          <Link className="cta primary" to="/onboarding">
             Ir a onboarding
           </Link>
         </div>
@@ -20,10 +22,12 @@ function Receive() {
 
   return (
     <div className="page">
-      <header className="header">
+      <TopBar />
+      <header className="section-header">
         <div>
-          <p className="subtitle">Recibir</p>
-          <h1 className="title">Comparte tu dirección eCash</h1>
+          <p className="eyebrow">Recibir</p>
+          <h1 className="section-title">Comparte tu dirección eCash</h1>
+          <p className="muted">Recibe RMZ y XEC en la misma dirección cifrada en tu dispositivo.</p>
         </div>
       </header>
 

--- a/src/routes/SendRMZ.tsx
+++ b/src/routes/SendRMZ.tsx
@@ -1,6 +1,7 @@
 import type { FormEvent } from 'react'
 import { useState } from 'react'
 import { useWallet } from '../context/WalletContext'
+import TopBar from '../components/TopBar'
 
 function SendRMZ() {
   const { sendRMZ, initialized, backupVerified, loading, error } = useWallet()
@@ -39,10 +40,12 @@ function SendRMZ() {
 
   return (
     <div className="page">
-      <header className="header">
+      <TopBar />
+      <header className="section-header">
         <div>
-          <p className="subtitle">Enviar</p>
-          <h1 className="title">RMZ hacia otra dirección</h1>
+          <p className="eyebrow">Enviar</p>
+          <h1 className="section-title">RMZ hacia otra dirección</h1>
+          <p className="muted">Mueve RMZ con confianza sobre la red eCash.</p>
         </div>
       </header>
 

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -1,10 +1,14 @@
+import TopBar from '../components/TopBar'
+
 function Settings() {
   return (
     <div className="page">
-      <header className="header">
+      <TopBar />
+      <header className="section-header">
         <div>
-          <p className="subtitle">Ajustes</p>
-          <h1 className="title">Próximamente</h1>
+          <p className="eyebrow">Ajustes</p>
+          <h1 className="section-title">Próximamente</h1>
+          <p className="muted">Controles de respaldo, idioma y más vivirán aquí.</p>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- add a reusable TopBar with the XolosArmy logo and wrap the app in a styled shell
- redesign onboarding hero/actions and page copy to highlight RMZWallet flows in Spanish
- refresh global styling and page headers to match the copper/teal brand palette across dashboard, send, receive, and backup screens

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923a5d5df7883328d1afca6eccbfb42)