### PR TITLE
Add XoloLegend link to DEX actions

### DIFF
--- a/src/routes/DEX.tsx
+++ b/src/routes/DEX.tsx
@@ -848,6 +848,22 @@ function DEX() {
           >
             Mint Pass
           </button>
+
+          {/* Botón Marketplace Externo */}
+          <a
+            href="https://xololegend.xyz"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="cta outline"
+            style={{
+              marginLeft: 'auto',
+              borderColor: 'var(--teal)',
+              color: 'var(--teal)',
+              borderStyle: 'dashed',
+            }}
+          >
+            🛒 Adquirir RMZ en XoloLegend
+          </a>
         </div>
 
         {dexTab === 'maker' && (


### PR DESCRIPTION
### Motivation
- Añadir un acceso directo al marketplace externo XoloLegend desde la barra de acciones del DEX para facilitar la adquisición de RMZ.
- Mantener la estética y comportamiento visual existente reutilizando las clases `cta` y `outline` del proyecto.
- Alinear el enlace a la derecha del grupo de acciones para separar visualmente el marketplace externo de las funciones internas del DEX.

### Description
- Insertada una etiqueta de enlace externa después del botón `Mint Pass` en `src/routes/DEX.tsx` para mostrar el botón `🛒 Adquirir RMZ en XoloLegend` en la barra de acciones.
- El enlace usa `className="cta outline"`, `rel="noopener noreferrer"` y estilos inline (`marginLeft: 'auto'`, `borderColor: 'var(--teal)'`, `borderStyle: 'dashed'`) para respetar el tema y accesibilidad.
- El enlace abre `https://xololegend.xyz` en una nueva pestaña mediante `target="_blank"`.

### Testing
- Levanté la app de desarrollo con `npm run dev` y Vite informó que el servidor quedó listo, lo cual se inició correctamente.
- Ejecuté un script de Playwright que cargó la página y generó la captura `artifacts/dex-xololegend.png`, confirmando la renderización del nuevo botón.
- No se ejecutaron tests unitarios o de integración automatizados adicionales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651b6acd408332b73fee957a4064e8)