### PR TITLE
Update DEX marketplace button label to Xolos NFTs

### DIFF
--- a/src/routes/DEX.tsx
+++ b/src/routes/DEX.tsx
@@ -916,7 +916,7 @@ function DEX() {
               animation: 'pulse 2s infinite',
             }}
           >
-            🛒 ¡Comprar eToken $RMZ aquí!
+            🛒 Mercado Xolos NFTs
           </a>
         </div>
 


### PR DESCRIPTION
### Motivation
- Ajustar la copia del CTA del marketplace en la interfaz DEX para que invite claramente al mercado de NFTs de Xolos.

### Description
- Reemplazado el texto del enlace en `src/routes/DEX.tsx` desde `🛒 ¡Comprar eToken $RMZ aquí!` a `🛒 Mercado Xolos NFTs` dentro del bloque del botón de marketplace externo.

### Testing
- No se ejecutaron pruebas automatizadas; se verificó con `rg` que la nueva etiqueta aparece en `src/routes/DEX.tsx` y el cambio es exclusivamente de texto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4b078cf88332a3067917d8283fc7)