### PR TITLE
Update RMZ featured offer pricing descriptions

### DIFF
--- a/src/features/dex/components/DexTakerRmz.tsx
+++ b/src/features/dex/components/DexTakerRmz.tsx
@@ -5,13 +5,13 @@ import { useActiveOffers } from '../hooks/useActiveOffers'
 const FEATURED_OFFERS = [
   {
     id: '22b2856ea7913071216be589c0eb7b1ed5334810a5041cca2fdb0143761c07f1:1',
-    title: 'Pack Basico',
-    description: '100 RMZ por ~1000 XEC'
+    title: 'Pack Básico',
+    description: '100 RMZ por 50,000 XEC'
   },
   {
     id: '67e456dab49064ee289455f16e36db97eaa681a8c5d15ff3f57b072bb73ef49e:1',
     title: 'Pack Inversor',
-    description: '500 RMZ por ~4800 XEC'
+    description: '500 RMZ por 250,000 XEC'
   }
 ] as const
 


### PR DESCRIPTION
### Motivation

- Ensure the official RMZ store displays the correct XEC amounts using the conversion 1 RMZ = 500 XEC.

### Description

- Replaced the `FEATURED_OFFERS` array in `src/features/dex/components/DexTakerRmz.tsx` to update `Pack Básico` to `100 RMZ por 50,000 XEC`, `Pack Inversor` to `500 RMZ por 250,000 XEC`, and fixed the accent on `Pack Básico`.

### Testing

- Ran `git diff -- src/features/dex/components/DexTakerRmz.tsx` and inspected the file with `nl -ba src/features/dex/components/DexTakerRmz.tsx | sed -n '1,30p'`, both commands succeeded and no runtime tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4c02bc18833294d9048836246c1d)