### PR TITLE
Actualizar ofertas destacadas RMZ DEX (Workers y Teyolias)

### DIFF
--- a/src/features/dex/components/DexTakerRmz.tsx
+++ b/src/features/dex/components/DexTakerRmz.tsx
@@ -32,6 +32,16 @@ const FEATURED_OFFERS: FeaturedOffer[] = [
     id: '67e456dab49064ee289455f16e36db97eaa681a8c5d15ff3f57b072bb73ef49e:1',
     label: 'Pack Inversor',
     summary: '500 RMZ por 250,000 XEC'
+  },
+  {
+    id: '9932a3ca8285d76db96a9e646a09a4d9c7eaa1a5eb7ddeba8d16538e45e0724c:1',
+    label: 'Paquete Básico para Workers',
+    summary: 'Oferta para agregar workers en mining.ecash.mx'
+  },
+  {
+    id: 'b000e816b45aa2b835d74b275d5882651bb6c57d249700712c308068b3fbcb72:1',
+    label: 'Paquete para Crear Teyolias',
+    summary: 'Consigue los recursos necesarios para crear Teyolias'
   }
 ]
 


### PR DESCRIPTION
### Motivation
- Actualizar las ofertas destacadas en la pestaña de compras del DEX para exponer dos nuevos paquetes oficiales (Workers y Crear Teyolias) junto a los packs existentes.
- Garantizar que los IDs mostrados en la UI coincidan con las ofertas oficiales para que los usuarios puedan cargarlas directamente.

### Description
- Reemplacé la constante `FEATURED_OFFERS` en `src/features/dex/components/DexTakerRmz.tsx` para incluir cuatro entradas con los IDs, etiquetas y resúmenes provistos. 
- Se mantuvieron las entradas existentes `Pack Básico` y `Pack Inversor` y se añadieron `Paquete Básico para Workers` y `Paquete para Crear Teyolias`.
- La UI del componente ahora renderiza cuatro botones `Cargar oferta` que cargan los IDs desde la nueva lista.

### Testing
- Ejecuté `git diff` para verificar el parche y confirmé que `FEATURED_OFFERS` fue actualizado correctamente (éxito).
- Ejecuté `git commit` para guardar el cambio en la rama actual (éxito).
- Inspeccioné el archivo modificado con `nl -ba` para confirmar las líneas afectadas y los contenidos actualizados (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1308a451108332a8bd90ecaad4d7c4)